### PR TITLE
Only dispose when we are at 0 refcounts

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -23,7 +23,9 @@ fn RefCounted(comptime T: type) type {
 
             self.ref_count -= 1;
 
-            self.item.deinit();
+            if (self.ref_count == 0) {
+                self.item.deinit();
+            }
         }
     };
 }


### PR DESCRIPTION
This is a small mistake i made in the original PR

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.