### PR TITLE
vulkan: make it work on windows

### DIFF
--- a/src/vulkan/Instance.zig
+++ b/src/vulkan/Instance.zig
@@ -106,7 +106,7 @@ fn getExtensions(base: Base) ![]const [*:0]const u8 {
             vk.extension_info.khr_xcb_surface.name,
             vk.extension_info.khr_wayland_surface.name,
         },
-        .windows => &.{vk.extension_info.khr_win_32_keyed_mutex.name},
+        .windows => &.{vk.extension_info.khr_win_32_surface.name},
         .macos, .ios => &.{vk.extension_info.ext_metal_surface.name},
         else => if (builtin.target.abi == .android)
             &.{vk.extension_info.khr_android_surface.name}

--- a/src/vulkan/Surface.zig
+++ b/src/vulkan/Surface.zig
@@ -21,6 +21,17 @@ pub fn init(instance: *Instance, desc: *const gpu.Surface.Descriptor) !Surface {
                 null,
             ),
         };
+    } else if (findChained(gpu.Surface.DescriptorFromWindowsHWND, desc.next_in_chain.generic)) |win_descriptor| {
+        return .{
+            .surface = try instance.dispatch.createWin32SurfaceKHR(
+                instance.instance,
+                &vk.Win32SurfaceCreateInfoKHR{
+                    .hinstance = @ptrCast(win_descriptor.hinstance),
+                    .hwnd = @ptrCast(win_descriptor.hwnd),
+                },
+                null,
+            ),
+        };
     }
 
     unreachable;


### PR DESCRIPTION
there's still an issue with package manager so running triangle example on windows requires copy/pasting vk.zig from hexops/vulkan-zig-generated



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.