### PR TITLE
dgpu: add dgpu.Interface which is Dusk's custom graphics API

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "1220789870c34138932c186f50662909b0a3522fb9ea04f7b1c1a1253c5cd5fedc05",
         },
         .mach_gpu = .{
-            .url = "https://pkg.machengine.org/mach-gpu/46d62d5c63f524228edeba06c7bb38f0015272cc.tar.gz",
-            .hash = "12209e517b8b459b95fb66f045580a66f8901970e7416f2ae90613df63adb710e19c",
+            .url = "https://pkg.machengine.org/mach-gpu/26c9273ab19ebd0368c0a598907943f2c5ed1f73.tar.gz",
+            .hash = "1220f784698f085674f8c083e9a58728772e35b563c88c43eaecae94bba15cbf2655",
         },
         .mach_objc = .{
             .url = "https://pkg.machengine.org/mach-objc/ad08011e984e8b4fdec40a53c7f610a4cd997a96.tar.gz",

--- a/src/d3d12.zig
+++ b/src/d3d12.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const gpu = @import("gpu");
+const dgpu = @import("dgpu/main.zig");
 const utils = @import("utils.zig");
 const shader = @import("shader.zig");
 const c = @import("d3d12/c.zig");
@@ -32,7 +32,7 @@ pub const Instance = struct {
     manager: utils.Manager(Instance) = .{},
     dxgi_factory: *c.IDXGIFactory4,
 
-    pub fn init(desc: *const gpu.Instance.Descriptor) !*Instance {
+    pub fn init(desc: *const dgpu.Instance.Descriptor) !*Instance {
         // TODO
         _ = desc;
 
@@ -80,7 +80,7 @@ pub const Instance = struct {
         allocator.destroy(instance);
     }
 
-    pub fn createSurface(instance: *Instance, desc: *const gpu.Surface.Descriptor) !*Surface {
+    pub fn createSurface(instance: *Instance, desc: *const dgpu.Surface.Descriptor) !*Surface {
         return Surface.init(instance, desc);
     }
 };
@@ -92,7 +92,7 @@ pub const Adapter = struct {
     d3d_device: *c.ID3D12Device,
     dxgi_desc: c.DXGI_ADAPTER_DESC1,
 
-    pub fn init(instance: *Instance, options: *const gpu.RequestAdapterOptions) !*Adapter {
+    pub fn init(instance: *Instance, options: *const dgpu.RequestAdapterOptions) !*Adapter {
         // TODO - choose appropriate device from options
         _ = options;
 
@@ -150,11 +150,11 @@ pub const Adapter = struct {
         allocator.destroy(adapter);
     }
 
-    pub fn createDevice(adapter: *Adapter, desc: ?*const gpu.Device.Descriptor) !*Device {
+    pub fn createDevice(adapter: *Adapter, desc: ?*const dgpu.Device.Descriptor) !*Device {
         return Device.init(adapter, desc);
     }
 
-    pub fn getProperties(adapter: *Adapter) gpu.Adapter.Properties {
+    pub fn getProperties(adapter: *Adapter) dgpu.Adapter.Properties {
         const dxgi_desc = adapter.dxgi_desc;
 
         return .{
@@ -175,10 +175,10 @@ pub const Surface = struct {
     manager: utils.Manager(Surface) = .{},
     hwnd: c.HWND,
 
-    pub fn init(instance: *Instance, desc: *const gpu.Surface.Descriptor) !*Surface {
+    pub fn init(instance: *Instance, desc: *const dgpu.Surface.Descriptor) !*Surface {
         _ = instance;
 
-        if (utils.findChained(gpu.Surface.DescriptorFromWindowsHWND, desc.next_in_chain.generic)) |win_desc| {
+        if (utils.findChained(dgpu.Surface.DescriptorFromWindowsHWND, desc.next_in_chain.generic)) |win_desc| {
             var surface = try allocator.create(Surface);
             surface.* = .{ .hwnd = hwndCast(win_desc.hwnd) };
             return surface;
@@ -200,14 +200,14 @@ pub const Device = struct {
     root_signature: *c.ID3D12RootSignature,
     command_manager: *CommandManager,
     queue: *Queue,
-    lost_cb: ?gpu.Device.LostCallback = null,
+    lost_cb: ?dgpu.Device.LostCallback = null,
     lost_cb_userdata: ?*anyopaque = null,
-    log_cb: ?gpu.LoggingCallback = null,
+    log_cb: ?dgpu.LoggingCallback = null,
     log_cb_userdata: ?*anyopaque = null,
-    err_cb: ?gpu.ErrorCallback = null,
+    err_cb: ?dgpu.ErrorCallback = null,
     err_cb_userdata: ?*anyopaque = null,
 
-    pub fn init(adapter: *Adapter, desc: ?*const gpu.Device.Descriptor) !*Device {
+    pub fn init(adapter: *Adapter, desc: ?*const dgpu.Device.Descriptor) !*Device {
         // TODO
         _ = desc;
 
@@ -298,41 +298,41 @@ pub const Device = struct {
         allocator.destroy(device);
     }
 
-    pub fn createBindGroup(device: *Device, desc: *const gpu.BindGroup.Descriptor) !*BindGroup {
+    pub fn createBindGroup(device: *Device, desc: *const dgpu.BindGroup.Descriptor) !*BindGroup {
         _ = desc;
         _ = device;
         unreachable;
     }
 
-    pub fn createBindGroupLayout(device: *Device, desc: *const gpu.BindGroupLayout.Descriptor) !*BindGroupLayout {
+    pub fn createBindGroupLayout(device: *Device, desc: *const dgpu.BindGroupLayout.Descriptor) !*BindGroupLayout {
         _ = device;
         _ = desc;
         unreachable;
     }
 
-    pub fn createBuffer(device: *Device, desc: *const gpu.Buffer.Descriptor) !*Buffer {
+    pub fn createBuffer(device: *Device, desc: *const dgpu.Buffer.Descriptor) !*Buffer {
         _ = desc;
         _ = device;
         unreachable;
     }
 
-    pub fn createCommandEncoder(device: *Device, desc: *const gpu.CommandEncoder.Descriptor) !*CommandEncoder {
+    pub fn createCommandEncoder(device: *Device, desc: *const dgpu.CommandEncoder.Descriptor) !*CommandEncoder {
         return CommandEncoder.init(device, desc);
     }
 
-    pub fn createComputePipeline(device: *Device, desc: *const gpu.ComputePipeline.Descriptor) !*ComputePipeline {
+    pub fn createComputePipeline(device: *Device, desc: *const dgpu.ComputePipeline.Descriptor) !*ComputePipeline {
         _ = desc;
         _ = device;
         unreachable;
     }
 
-    pub fn createPipelineLayout(device: *Device, desc: *const gpu.PipelineLayout.Descriptor) !*PipelineLayout {
+    pub fn createPipelineLayout(device: *Device, desc: *const dgpu.PipelineLayout.Descriptor) !*PipelineLayout {
         _ = device;
         _ = desc;
         unreachable;
     }
 
-    pub fn createRenderPipeline(device: *Device, desc: *const gpu.RenderPipeline.Descriptor) !*RenderPipeline {
+    pub fn createRenderPipeline(device: *Device, desc: *const dgpu.RenderPipeline.Descriptor) !*RenderPipeline {
         return RenderPipeline.init(device, desc);
     }
 
@@ -346,11 +346,11 @@ pub const Device = struct {
         return error.unsupported;
     }
 
-    pub fn createSwapChain(device: *Device, surface: *Surface, desc: *const gpu.SwapChain.Descriptor) !*SwapChain {
+    pub fn createSwapChain(device: *Device, surface: *Surface, desc: *const dgpu.SwapChain.Descriptor) !*SwapChain {
         return SwapChain.init(device, surface, desc);
     }
 
-    pub fn createTexture(device: *Device, desc: *const gpu.Texture.Descriptor) !*Texture {
+    pub fn createTexture(device: *Device, desc: *const dgpu.Texture.Descriptor) !*Texture {
         _ = desc;
         _ = device;
         unreachable;
@@ -522,7 +522,7 @@ pub const SwapChain = struct {
     buffer_index: u32 = 0,
     texture_view: TextureView = undefined,
 
-    pub fn init(device: *Device, surface: *Surface, desc: *const gpu.SwapChain.Descriptor) !*SwapChain {
+    pub fn init(device: *Device, surface: *Surface, desc: *const dgpu.SwapChain.Descriptor) !*SwapChain {
         const dxgi_factory = device.adapter.instance.dxgi_factory;
         const d3d_device = device.d3d_device;
         const rtv_descriptor_heap = device.rtv_descriptor_heap;
@@ -676,7 +676,7 @@ pub const SwapChain = struct {
 pub const Buffer = struct {
     manager: utils.Manager(Buffer) = .{},
 
-    pub fn init(device: *Device, desc: *const gpu.Buffer.Descriptor) !*Buffer {
+    pub fn init(device: *Device, desc: *const dgpu.Buffer.Descriptor) !*Buffer {
         _ = desc;
         _ = device;
         unreachable;
@@ -693,7 +693,7 @@ pub const Buffer = struct {
         unreachable;
     }
 
-    pub fn mapAsync(buffer: *Buffer, mode: gpu.MapModeFlags, offset: usize, size: usize, callback: gpu.Buffer.MapCallback, userdata: ?*anyopaque) !void {
+    pub fn mapAsync(buffer: *Buffer, mode: dgpu.MapModeFlags, offset: usize, size: usize, callback: dgpu.Buffer.MapCallback, userdata: ?*anyopaque) !void {
         _ = userdata;
         _ = callback;
         _ = size;
@@ -717,7 +717,7 @@ pub const Texture = struct {
         _ = view;
     }
 
-    pub fn createView(texture: *Texture, desc: ?*const gpu.TextureView.Descriptor) !*TextureView {
+    pub fn createView(texture: *Texture, desc: ?*const dgpu.TextureView.Descriptor) !*TextureView {
         _ = desc;
         _ = texture;
         unreachable;
@@ -747,7 +747,7 @@ pub const BindGroupLayout = struct {
 pub const BindGroup = struct {
     manager: utils.Manager(BindGroup) = .{},
 
-    pub fn init(device: *Device, desc: *const gpu.BindGroup.Descriptor) !*BindGroup {
+    pub fn init(device: *Device, desc: *const dgpu.BindGroup.Descriptor) !*BindGroup {
         _ = desc;
         _ = device;
         unreachable;
@@ -761,7 +761,7 @@ pub const BindGroup = struct {
 pub const PipelineLayout = struct {
     manager: utils.Manager(PipelineLayout) = .{},
 
-    pub fn init(device: *Device, desc: *const gpu.PipelineLayout.Descriptor) !*PipelineLayout {
+    pub fn init(device: *Device, desc: *const dgpu.PipelineLayout.Descriptor) !*PipelineLayout {
         _ = desc;
         _ = device;
         unreachable;
@@ -798,7 +798,7 @@ pub const ShaderModule = struct {
 pub const ComputePipeline = struct {
     manager: utils.Manager(ComputePipeline) = .{},
 
-    pub fn init(device: *Device, desc: *const gpu.ComputePipeline.Descriptor) !*ComputePipeline {
+    pub fn init(device: *Device, desc: *const dgpu.ComputePipeline.Descriptor) !*ComputePipeline {
         _ = desc;
         _ = device;
         unreachable;
@@ -849,7 +849,7 @@ pub const RenderPipeline = struct {
         return shader_blob;
     }
 
-    pub fn init(device: *Device, desc: *const gpu.RenderPipeline.Descriptor) !*RenderPipeline {
+    pub fn init(device: *Device, desc: *const dgpu.RenderPipeline.Descriptor) !*RenderPipeline {
         const d3d_device = device.d3d_device;
         var hr: c.HRESULT = undefined;
 
@@ -1031,7 +1031,7 @@ pub const CommandEncoder = struct {
     manager: utils.Manager(CommandEncoder) = .{},
     cmd_buffer: *CommandBuffer,
 
-    pub fn init(device: *Device, desc: ?*const gpu.CommandEncoder.Descriptor) !*CommandEncoder {
+    pub fn init(device: *Device, desc: ?*const dgpu.CommandEncoder.Descriptor) !*CommandEncoder {
         // TODO
         _ = desc;
 
@@ -1046,13 +1046,13 @@ pub const CommandEncoder = struct {
         allocator.destroy(cmd_encoder);
     }
 
-    pub fn beginComputePass(encoder: *CommandEncoder, desc: *const gpu.ComputePassDescriptor) !*ComputePassEncoder {
+    pub fn beginComputePass(encoder: *CommandEncoder, desc: *const dgpu.ComputePassDescriptor) !*ComputePassEncoder {
         _ = desc;
         _ = encoder;
         unreachable;
     }
 
-    pub fn beginRenderPass(cmd_encoder: *CommandEncoder, desc: *const gpu.RenderPassDescriptor) !*RenderPassEncoder {
+    pub fn beginRenderPass(cmd_encoder: *CommandEncoder, desc: *const dgpu.RenderPassDescriptor) !*RenderPassEncoder {
         return RenderPassEncoder.init(cmd_encoder, desc);
     }
 
@@ -1066,7 +1066,7 @@ pub const CommandEncoder = struct {
         unreachable;
     }
 
-    pub fn finish(cmd_encoder: *CommandEncoder, desc: *const gpu.CommandBuffer.Descriptor) !*CommandBuffer {
+    pub fn finish(cmd_encoder: *CommandEncoder, desc: *const dgpu.CommandBuffer.Descriptor) !*CommandBuffer {
         // TODO
         _ = desc;
 
@@ -1085,7 +1085,7 @@ pub const CommandEncoder = struct {
 pub const ComputePassEncoder = struct {
     manager: utils.Manager(ComputePassEncoder) = .{},
 
-    pub fn init(command_encoder: *CommandEncoder, desc: *const gpu.ComputePassDescriptor) !*ComputePassEncoder {
+    pub fn init(command_encoder: *CommandEncoder, desc: *const dgpu.ComputePassDescriptor) !*ComputePassEncoder {
         _ = desc;
         _ = command_encoder;
         unreachable;
@@ -1130,7 +1130,7 @@ pub const RenderPassEncoder = struct {
     color_attachment_count: usize,
     color_resources: [max_color_attachments]*c.ID3D12Resource,
 
-    pub fn init(cmd_encoder: *CommandEncoder, desc: *const gpu.RenderPassDescriptor) !*RenderPassEncoder {
+    pub fn init(cmd_encoder: *CommandEncoder, desc: *const dgpu.RenderPassDescriptor) !*RenderPassEncoder {
         const command_list = cmd_encoder.cmd_buffer.command_list;
 
         var width: u32 = 0;

--- a/src/d3d12/conv.zig
+++ b/src/d3d12/conv.zig
@@ -1,2 +1,2 @@
-const gpu = @import("gpu");
+const dgpu = @import("../dgpu/main.zig");
 const c = @import("c.zig");

--- a/src/dgpu/adapter.zig
+++ b/src/dgpu/adapter.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const testing = std.testing;
+const dawn = @import("dawn.zig");
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStructOut = @import("main.zig").ChainedStructOut;
+const Device = @import("device.zig").Device;
+const Instance = @import("instance.zig").Instance;
+const FeatureName = @import("main.zig").FeatureName;
+const SupportedLimits = @import("main.zig").SupportedLimits;
+const RequestDeviceStatus = @import("main.zig").RequestDeviceStatus;
+const BackendType = @import("main.zig").BackendType;
+const RequestDeviceCallback = @import("main.zig").RequestDeviceCallback;
+const Impl = @import("interface.zig").Impl;
+
+pub const Adapter = opaque {
+    pub const Type = enum(u32) {
+        discrete_gpu,
+        integrated_gpu,
+        cpu,
+        unknown,
+
+        pub fn name(t: Type) []const u8 {
+            return switch (t) {
+                .discrete_gpu => "Discrete GPU",
+                .integrated_gpu => "Integrated GPU",
+                .cpu => "CPU",
+                .unknown => "Unknown",
+            };
+        }
+    };
+
+    pub const Properties = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStructOut,
+            dawn_adapter_properties_power_preference: *const dawn.AdapterPropertiesPowerPreference,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        vendor_id: u32,
+        vendor_name: [*:0]const u8,
+        architecture: [*:0]const u8,
+        device_id: u32,
+        name: [*:0]const u8,
+        driver_description: [*:0]const u8,
+        adapter_type: Type,
+        backend_type: BackendType,
+        compatibility_mode: Bool32 = .false,
+    };
+
+    pub inline fn createDevice(adapter: *Adapter, descriptor: ?*const Device.Descriptor) ?*Device {
+        return Impl.adapterCreateDevice(adapter, descriptor);
+    }
+
+    /// Call once with null to determine the array length, and again to fetch the feature list.
+    ///
+    /// Consider using the enumerateFeaturesOwned helper.
+    pub inline fn enumerateFeatures(adapter: *Adapter, features: ?[*]FeatureName) usize {
+        return Impl.adapterEnumerateFeatures(adapter, features);
+    }
+
+    /// Enumerates the adapter features, storing the result in an allocated slice which is owned by
+    /// the caller.
+    pub inline fn enumerateFeaturesOwned(adapter: *Adapter, allocator: std.mem.Allocator) ![]FeatureName {
+        const count = adapter.enumerateFeatures(null);
+        var data = try allocator.alloc(FeatureName, count);
+        _ = adapter.enumerateFeatures(data.ptr);
+        return data;
+    }
+
+    pub inline fn getInstance(adapter: *Adapter) *Instance {
+        return Impl.adapterGetInstance(adapter);
+    }
+
+    pub inline fn getLimits(adapter: *Adapter, limits: *SupportedLimits) bool {
+        return Impl.adapterGetLimits(adapter, limits);
+    }
+
+    pub inline fn getProperties(adapter: *Adapter, properties: *Adapter.Properties) void {
+        Impl.adapterGetProperties(adapter, properties);
+    }
+
+    pub inline fn hasFeature(adapter: *Adapter, feature: FeatureName) bool {
+        return Impl.adapterHasFeature(adapter, feature);
+    }
+
+    pub inline fn requestDevice(
+        adapter: *Adapter,
+        descriptor: ?*const Device.Descriptor,
+        context: anytype,
+        comptime callback: fn (
+            ctx: @TypeOf(context),
+            status: RequestDeviceStatus,
+            device: *Device,
+            message: ?[*:0]const u8,
+        ) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(status: RequestDeviceStatus, device: *Device, message: ?[*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
+                callback(
+                    if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))),
+                    status,
+                    device,
+                    message,
+                );
+            }
+        };
+        Impl.adapterRequestDevice(adapter, descriptor, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn reference(adapter: *Adapter) void {
+        Impl.adapterReference(adapter);
+    }
+
+    pub inline fn release(adapter: *Adapter) void {
+        Impl.adapterRelease(adapter);
+    }
+};
+
+test "Adapter.Type name" {
+    try testing.expectEqualStrings("Discrete GPU", Adapter.Type.discrete_gpu.name());
+}

--- a/src/dgpu/bind_group.zig
+++ b/src/dgpu/bind_group.zig
@@ -1,0 +1,88 @@
+const Buffer = @import("buffer.zig").Buffer;
+const Sampler = @import("sampler.zig").Sampler;
+const TextureView = @import("texture_view.zig").TextureView;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+const ExternalTexture = @import("external_texture.zig").ExternalTexture;
+const Impl = @import("interface.zig").Impl;
+
+pub const BindGroup = opaque {
+    pub const Entry = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            external_texture_binding_entry: *const ExternalTexture.BindingEntry,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        binding: u32,
+        buffer: ?*Buffer = null,
+        offset: u64 = 0,
+        size: u64,
+        sampler: ?*Sampler = null,
+        texture_view: ?*TextureView = null,
+
+        /// Helper to create a buffer BindGroup.Entry.
+        pub fn buffer(binding: u32, buf: *Buffer, offset: u64, size: u64) Entry {
+            return .{
+                .binding = binding,
+                .buffer = buf,
+                .offset = offset,
+                .size = size,
+            };
+        }
+
+        /// Helper to create a sampler BindGroup.Entry.
+        pub fn sampler(binding: u32, _sampler: *Sampler) Entry {
+            return .{
+                .binding = binding,
+                .sampler = _sampler,
+                .size = 0,
+            };
+        }
+
+        /// Helper to create a texture view BindGroup.Entry.
+        pub fn textureView(binding: u32, texture_view: *TextureView) Entry {
+            return .{
+                .binding = binding,
+                .texture_view = texture_view,
+                .size = 0,
+            };
+        }
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        layout: *BindGroupLayout,
+        entry_count: usize = 0,
+        entries: ?[*]const Entry = null,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: ?*const ChainedStruct = null,
+            label: ?[*:0]const u8 = null,
+            layout: *BindGroupLayout,
+            entries: ?[]const Entry = null,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .layout = v.layout,
+                .entry_count = if (v.entries) |e| e.len else 0,
+                .entries = if (v.entries) |e| e.ptr else null,
+            };
+        }
+    };
+
+    pub inline fn setLabel(bind_group: *BindGroup, label: [*:0]const u8) void {
+        Impl.bindGroupSetLabel(bind_group, label);
+    }
+
+    pub inline fn reference(bind_group: *BindGroup) void {
+        Impl.bindGroupReference(bind_group);
+    }
+
+    pub inline fn release(bind_group: *BindGroup) void {
+        Impl.bindGroupRelease(bind_group);
+    }
+};

--- a/src/dgpu/bind_group_layout.zig
+++ b/src/dgpu/bind_group_layout.zig
@@ -1,0 +1,131 @@
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ShaderStageFlags = @import("main.zig").ShaderStageFlags;
+const Buffer = @import("buffer.zig").Buffer;
+const Sampler = @import("sampler.zig").Sampler;
+const Texture = @import("texture.zig").Texture;
+const TextureView = @import("texture_view.zig").TextureView;
+const StorageTextureBindingLayout = @import("main.zig").StorageTextureBindingLayout;
+const StorageTextureAccess = @import("main.zig").StorageTextureAccess;
+const ExternalTexture = @import("external_texture.zig").ExternalTexture;
+const Impl = @import("interface.zig").Impl;
+
+pub const BindGroupLayout = opaque {
+    pub const Entry = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            external_texture_binding_layout: *const ExternalTexture.BindingLayout,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        binding: u32,
+        visibility: ShaderStageFlags,
+        buffer: Buffer.BindingLayout = .{},
+        sampler: Sampler.BindingLayout = .{},
+        texture: Texture.BindingLayout = .{},
+        storage_texture: StorageTextureBindingLayout = .{},
+
+        /// Helper to create a buffer BindGroupLayout.Entry.
+        pub fn buffer(
+            binding: u32,
+            visibility: ShaderStageFlags,
+            binding_type: Buffer.BindingType,
+            has_dynamic_offset: bool,
+            min_binding_size: u64,
+        ) Entry {
+            return .{
+                .binding = binding,
+                .visibility = visibility,
+                .buffer = .{
+                    .type = binding_type,
+                    .has_dynamic_offset = Bool32.from(has_dynamic_offset),
+                    .min_binding_size = min_binding_size,
+                },
+            };
+        }
+
+        /// Helper to create a sampler BindGroupLayout.Entry.
+        pub fn sampler(
+            binding: u32,
+            visibility: ShaderStageFlags,
+            binding_type: Sampler.BindingType,
+        ) Entry {
+            return .{
+                .binding = binding,
+                .visibility = visibility,
+                .sampler = .{ .type = binding_type },
+            };
+        }
+
+        /// Helper to create a texture BindGroupLayout.Entry.
+        pub fn texture(
+            binding: u32,
+            visibility: ShaderStageFlags,
+            sample_type: Texture.SampleType,
+            view_dimension: TextureView.Dimension,
+            multisampled: bool,
+        ) Entry {
+            return .{
+                .binding = binding,
+                .visibility = visibility,
+                .texture = .{
+                    .sample_type = sample_type,
+                    .view_dimension = view_dimension,
+                    .multisampled = Bool32.from(multisampled),
+                },
+            };
+        }
+
+        /// Helper to create a storage texture BindGroupLayout.Entry.
+        pub fn storageTexture(
+            binding: u32,
+            visibility: ShaderStageFlags,
+            access: StorageTextureAccess,
+            format: Texture.Format,
+            view_dimension: TextureView.Dimension,
+        ) Entry {
+            return .{
+                .binding = binding,
+                .visibility = visibility,
+                .storage_texture = .{
+                    .access = access,
+                    .format = format,
+                    .view_dimension = view_dimension,
+                },
+            };
+        }
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        entry_count: usize = 0,
+        entries: ?[*]const Entry = null,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: ?*const ChainedStruct = null,
+            label: ?[*:0]const u8 = null,
+            entries: ?[]const Entry = null,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .entry_count = if (v.entries) |e| e.len else 0,
+                .entries = if (v.entries) |e| e.ptr else null,
+            };
+        }
+    };
+
+    pub inline fn setLabel(bind_group_layout: *BindGroupLayout, label: [*:0]const u8) void {
+        Impl.bindGroupLayoutSetLabel(bind_group_layout, label);
+    }
+
+    pub inline fn reference(bind_group_layout: *BindGroupLayout) void {
+        Impl.bindGroupLayoutReference(bind_group_layout);
+    }
+
+    pub inline fn release(bind_group_layout: *BindGroupLayout) void {
+        Impl.bindGroupLayoutRelease(bind_group_layout);
+    }
+};

--- a/src/dgpu/buffer.zig
+++ b/src/dgpu/buffer.zig
@@ -1,0 +1,166 @@
+const std = @import("std");
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const dawn = @import("dawn.zig");
+const MapModeFlags = @import("main.zig").MapModeFlags;
+const Impl = @import("interface.zig").Impl;
+
+pub const Buffer = opaque {
+    pub const MapCallback = *const fn (status: MapAsyncStatus, userdata: ?*anyopaque) callconv(.C) void;
+
+    pub const BindingType = enum(u32) {
+        undefined = 0x00000000,
+        uniform = 0x00000001,
+        storage = 0x00000002,
+        read_only_storage = 0x00000003,
+    };
+
+    pub const MapState = enum(u32) {
+        unmapped = 0x00000000,
+        pending = 0x00000001,
+        mapped = 0x00000002,
+    };
+
+    pub const MapAsyncStatus = enum(u32) {
+        success = 0x00000000,
+        validation_error = 0x00000001,
+        unknown = 0x00000002,
+        device_lost = 0x00000003,
+        destroyed_before_callback = 0x00000004,
+        unmapped_before_callback = 0x00000005,
+        mapping_already_pending = 0x00000006,
+        offset_out_of_range = 0x00000007,
+        size_out_of_range = 0x00000008,
+    };
+
+    pub const UsageFlags = packed struct(u32) {
+        map_read: bool = false,
+        map_write: bool = false,
+        copy_src: bool = false,
+        copy_dst: bool = false,
+        index: bool = false,
+        vertex: bool = false,
+        uniform: bool = false,
+        storage: bool = false,
+        indirect: bool = false,
+        query_resolve: bool = false,
+
+        _padding: u22 = 0,
+
+        comptime {
+            std.debug.assert(
+                @sizeOf(@This()) == @sizeOf(u32) and
+                    @bitSizeOf(@This()) == @bitSizeOf(u32),
+            );
+        }
+
+        pub const none = UsageFlags{};
+
+        pub fn equal(a: UsageFlags, b: UsageFlags) bool {
+            return @as(u10, @truncate(@as(u32, @bitCast(a)))) == @as(u10, @truncate(@as(u32, @bitCast(b))));
+        }
+    };
+
+    pub const BindingLayout = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        type: BindingType = .undefined,
+        has_dynamic_offset: Bool32 = .false,
+        min_binding_size: u64 = 0,
+    };
+
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            dawn_buffer_descriptor_error_info_from_wire_client: *const dawn.BufferDescriptorErrorInfoFromWireClient,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+        usage: UsageFlags,
+        size: u64,
+        mapped_at_creation: Bool32 = .false,
+    };
+
+    pub inline fn destroy(buffer: *Buffer) void {
+        Impl.bufferDestroy(buffer);
+    }
+
+    pub inline fn getMapState(buffer: *Buffer) MapState {
+        return Impl.bufferGetMapState(buffer);
+    }
+
+    /// Default `offset_bytes`: 0
+    /// Default `len`: `gpu.whole_map_size` / `std.math.maxint(usize)` (whole range)
+    pub inline fn getConstMappedRange(
+        buffer: *Buffer,
+        comptime T: type,
+        offset_bytes: usize,
+        len: usize,
+    ) ?[]const T {
+        const size = @sizeOf(T) * len;
+        const data = Impl.bufferGetConstMappedRange(
+            buffer,
+            offset_bytes,
+            size + size % 4,
+        );
+        return if (data) |d| @as([*]const T, @ptrCast(@alignCast(d)))[0..len] else null;
+    }
+
+    /// Default `offset_bytes`: 0
+    /// Default `len`: `gpu.whole_map_size` / `std.math.maxint(usize)` (whole range)
+    pub inline fn getMappedRange(
+        buffer: *Buffer,
+        comptime T: type,
+        offset_bytes: usize,
+        len: usize,
+    ) ?[]T {
+        const size = @sizeOf(T) * len;
+        const data = Impl.bufferGetMappedRange(
+            buffer,
+            offset_bytes,
+            size + size % 4,
+        );
+        return if (data) |d| @as([*]T, @ptrCast(@alignCast(d)))[0..len] else null;
+    }
+
+    pub inline fn getSize(buffer: *Buffer) u64 {
+        return Impl.bufferGetSize(buffer);
+    }
+
+    pub inline fn getUsage(buffer: *Buffer) Buffer.UsageFlags {
+        return Impl.bufferGetUsage(buffer);
+    }
+
+    pub inline fn mapAsync(
+        buffer: *Buffer,
+        mode: MapModeFlags,
+        offset: usize,
+        size: usize,
+        context: anytype,
+        comptime callback: fn (ctx: @TypeOf(context), status: MapAsyncStatus) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(status: MapAsyncStatus, userdata: ?*anyopaque) callconv(.C) void {
+                callback(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), status);
+            }
+        };
+        Impl.bufferMapAsync(buffer, mode, offset, size, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn setLabel(buffer: *Buffer, label: [*:0]const u8) void {
+        Impl.bufferSetLabel(buffer, label);
+    }
+
+    pub inline fn unmap(buffer: *Buffer) void {
+        Impl.bufferUnmap(buffer);
+    }
+
+    pub inline fn reference(buffer: *Buffer) void {
+        Impl.bufferReference(buffer);
+    }
+
+    pub inline fn release(buffer: *Buffer) void {
+        Impl.bufferRelease(buffer);
+    }
+};

--- a/src/dgpu/command_buffer.zig
+++ b/src/dgpu/command_buffer.zig
@@ -1,0 +1,21 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const Impl = @import("interface.zig").Impl;
+
+pub const CommandBuffer = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub inline fn setLabel(command_buffer: *CommandBuffer, label: [*:0]const u8) void {
+        Impl.commandBufferSetLabel(command_buffer, label);
+    }
+
+    pub inline fn reference(command_buffer: *CommandBuffer) void {
+        Impl.commandBufferReference(command_buffer);
+    }
+
+    pub inline fn release(command_buffer: *CommandBuffer) void {
+        Impl.commandBufferRelease(command_buffer);
+    }
+};

--- a/src/dgpu/command_encoder.zig
+++ b/src/dgpu/command_encoder.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const ComputePassEncoder = @import("compute_pass_encoder.zig").ComputePassEncoder;
+const RenderPassEncoder = @import("render_pass_encoder.zig").RenderPassEncoder;
+const CommandBuffer = @import("command_buffer.zig").CommandBuffer;
+const Buffer = @import("buffer.zig").Buffer;
+const QuerySet = @import("query_set.zig").QuerySet;
+const RenderPassDescriptor = @import("main.zig").RenderPassDescriptor;
+const ComputePassDescriptor = @import("main.zig").ComputePassDescriptor;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ImageCopyBuffer = @import("main.zig").ImageCopyBuffer;
+const ImageCopyTexture = @import("main.zig").ImageCopyTexture;
+const Extent3D = @import("main.zig").Extent3D;
+const Impl = @import("interface.zig").Impl;
+const dawn = @import("dawn.zig");
+
+pub const CommandEncoder = opaque {
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            dawn_encoder_internal_usage_descriptor: *const dawn.EncoderInternalUsageDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub inline fn beginComputePass(command_encoder: *CommandEncoder, descriptor: ?*const ComputePassDescriptor) *ComputePassEncoder {
+        return Impl.commandEncoderBeginComputePass(command_encoder, descriptor);
+    }
+
+    pub inline fn beginRenderPass(command_encoder: *CommandEncoder, descriptor: *const RenderPassDescriptor) *RenderPassEncoder {
+        return Impl.commandEncoderBeginRenderPass(command_encoder, descriptor);
+    }
+
+    /// Default `offset`: 0
+    /// Default `size`: `gpu.whole_size`
+    pub inline fn clearBuffer(command_encoder: *CommandEncoder, buffer: *Buffer, offset: u64, size: u64) void {
+        Impl.commandEncoderClearBuffer(command_encoder, buffer, offset, size);
+    }
+
+    pub inline fn copyBufferToBuffer(command_encoder: *CommandEncoder, source: *Buffer, source_offset: u64, destination: *Buffer, destination_offset: u64, size: u64) void {
+        Impl.commandEncoderCopyBufferToBuffer(command_encoder, source, source_offset, destination, destination_offset, size);
+    }
+
+    pub inline fn copyBufferToTexture(command_encoder: *CommandEncoder, source: *const ImageCopyBuffer, destination: *const ImageCopyTexture, copy_size: *const Extent3D) void {
+        Impl.commandEncoderCopyBufferToTexture(command_encoder, source, destination, copy_size);
+    }
+
+    pub inline fn copyTextureToBuffer(command_encoder: *CommandEncoder, source: *const ImageCopyTexture, destination: *const ImageCopyBuffer, copy_size: *const Extent3D) void {
+        Impl.commandEncoderCopyTextureToBuffer(command_encoder, source, destination, copy_size);
+    }
+
+    pub inline fn copyTextureToTexture(command_encoder: *CommandEncoder, source: *const ImageCopyTexture, destination: *const ImageCopyTexture, copy_size: *const Extent3D) void {
+        Impl.commandEncoderCopyTextureToTexture(command_encoder, source, destination, copy_size);
+    }
+
+    pub inline fn finish(command_encoder: *CommandEncoder, descriptor: ?*const CommandBuffer.Descriptor) *CommandBuffer {
+        return Impl.commandEncoderFinish(command_encoder, descriptor);
+    }
+
+    pub inline fn injectValidationError(command_encoder: *CommandEncoder, message: [*:0]const u8) void {
+        Impl.commandEncoderInjectValidationError(command_encoder, message);
+    }
+
+    pub inline fn insertDebugMarker(command_encoder: *CommandEncoder, marker_label: [*:0]const u8) void {
+        Impl.commandEncoderInsertDebugMarker(command_encoder, marker_label);
+    }
+
+    pub inline fn popDebugGroup(command_encoder: *CommandEncoder) void {
+        Impl.commandEncoderPopDebugGroup(command_encoder);
+    }
+
+    pub inline fn pushDebugGroup(command_encoder: *CommandEncoder, group_label: [*:0]const u8) void {
+        Impl.commandEncoderPushDebugGroup(command_encoder, group_label);
+    }
+
+    pub inline fn resolveQuerySet(command_encoder: *CommandEncoder, query_set: *QuerySet, first_query: u32, query_count: u32, destination: *Buffer, destination_offset: u64) void {
+        Impl.commandEncoderResolveQuerySet(command_encoder, query_set, first_query, query_count, destination, destination_offset);
+    }
+
+    pub inline fn setLabel(command_encoder: *CommandEncoder, label: [*:0]const u8) void {
+        Impl.commandEncoderSetLabel(command_encoder, label);
+    }
+
+    pub inline fn writeBuffer(
+        command_encoder: *CommandEncoder,
+        buffer: *Buffer,
+        buffer_offset_bytes: u64,
+        data_slice: anytype,
+    ) void {
+        Impl.commandEncoderWriteBuffer(
+            command_encoder,
+            buffer,
+            buffer_offset_bytes,
+            @as([*]const u8, @ptrCast(std.mem.sliceAsBytes(data_slice).ptr)),
+            @as(u64, @intCast(data_slice.len)) * @sizeOf(std.meta.Elem(@TypeOf(data_slice))),
+        );
+    }
+
+    pub inline fn writeTimestamp(command_encoder: *CommandEncoder, query_set: *QuerySet, query_index: u32) void {
+        Impl.commandEncoderWriteTimestamp(command_encoder, query_set, query_index);
+    }
+
+    pub inline fn reference(command_encoder: *CommandEncoder) void {
+        Impl.commandEncoderReference(command_encoder);
+    }
+
+    pub inline fn release(command_encoder: *CommandEncoder) void {
+        Impl.commandEncoderRelease(command_encoder);
+    }
+};

--- a/src/dgpu/compute_pass_encoder.zig
+++ b/src/dgpu/compute_pass_encoder.zig
@@ -1,0 +1,64 @@
+const Buffer = @import("buffer.zig").Buffer;
+const BindGroup = @import("bind_group.zig").BindGroup;
+const ComputePipeline = @import("compute_pipeline.zig").ComputePipeline;
+const QuerySet = @import("query_set.zig").QuerySet;
+const Impl = @import("interface.zig").Impl;
+
+pub const ComputePassEncoder = opaque {
+    /// Default `workgroup_count_y`: 1
+    /// Default `workgroup_count_z`: 1
+    pub inline fn dispatchWorkgroups(compute_pass_encoder: *ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void {
+        Impl.computePassEncoderDispatchWorkgroups(compute_pass_encoder, workgroup_count_x, workgroup_count_y, workgroup_count_z);
+    }
+
+    pub inline fn dispatchWorkgroupsIndirect(compute_pass_encoder: *ComputePassEncoder, indirect_buffer: *Buffer, indirect_offset: u64) void {
+        Impl.computePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder, indirect_buffer, indirect_offset);
+    }
+
+    pub inline fn end(compute_pass_encoder: *ComputePassEncoder) void {
+        Impl.computePassEncoderEnd(compute_pass_encoder);
+    }
+
+    pub inline fn insertDebugMarker(compute_pass_encoder: *ComputePassEncoder, marker_label: [*:0]const u8) void {
+        Impl.computePassEncoderInsertDebugMarker(compute_pass_encoder, marker_label);
+    }
+
+    pub inline fn popDebugGroup(compute_pass_encoder: *ComputePassEncoder) void {
+        Impl.computePassEncoderPopDebugGroup(compute_pass_encoder);
+    }
+
+    pub inline fn pushDebugGroup(compute_pass_encoder: *ComputePassEncoder, group_label: [*:0]const u8) void {
+        Impl.computePassEncoderPushDebugGroup(compute_pass_encoder, group_label);
+    }
+
+    /// Default `dynamic_offsets`: null
+    pub inline fn setBindGroup(compute_pass_encoder: *ComputePassEncoder, group_index: u32, group: *BindGroup, dynamic_offsets: ?[]const u32) void {
+        Impl.computePassEncoderSetBindGroup(
+            compute_pass_encoder,
+            group_index,
+            group,
+            if (dynamic_offsets) |v| v.len else 0,
+            if (dynamic_offsets) |v| v.ptr else null,
+        );
+    }
+
+    pub inline fn setLabel(compute_pass_encoder: *ComputePassEncoder, label: [*:0]const u8) void {
+        Impl.computePassEncoderSetLabel(compute_pass_encoder, label);
+    }
+
+    pub inline fn setPipeline(compute_pass_encoder: *ComputePassEncoder, pipeline: *ComputePipeline) void {
+        Impl.computePassEncoderSetPipeline(compute_pass_encoder, pipeline);
+    }
+
+    pub inline fn writeTimestamp(compute_pass_encoder: *ComputePassEncoder, query_set: *QuerySet, query_index: u32) void {
+        Impl.computePassEncoderWriteTimestamp(compute_pass_encoder, query_set, query_index);
+    }
+
+    pub inline fn reference(compute_pass_encoder: *ComputePassEncoder) void {
+        Impl.computePassEncoderReference(compute_pass_encoder);
+    }
+
+    pub inline fn release(compute_pass_encoder: *ComputePassEncoder) void {
+        Impl.computePassEncoderRelease(compute_pass_encoder);
+    }
+};

--- a/src/dgpu/compute_pipeline.zig
+++ b/src/dgpu/compute_pipeline.zig
@@ -1,0 +1,30 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ProgrammableStageDescriptor = @import("main.zig").ProgrammableStageDescriptor;
+const PipelineLayout = @import("pipeline_layout.zig").PipelineLayout;
+const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+const Impl = @import("interface.zig").Impl;
+
+pub const ComputePipeline = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        layout: ?*PipelineLayout = null,
+        compute: ProgrammableStageDescriptor,
+    };
+
+    pub inline fn getBindGroupLayout(compute_pipeline: *ComputePipeline, group_index: u32) *BindGroupLayout {
+        return Impl.computePipelineGetBindGroupLayout(compute_pipeline, group_index);
+    }
+
+    pub inline fn setLabel(compute_pipeline: *ComputePipeline, label: [*:0]const u8) void {
+        Impl.computePipelineSetLabel(compute_pipeline, label);
+    }
+
+    pub inline fn reference(compute_pipeline: *ComputePipeline) void {
+        Impl.computePipelineReference(compute_pipeline);
+    }
+
+    pub inline fn release(compute_pipeline: *ComputePipeline) void {
+        Impl.computePipelineRelease(compute_pipeline);
+    }
+};

--- a/src/dgpu/dawn.zig
+++ b/src/dgpu/dawn.zig
@@ -1,0 +1,74 @@
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ChainedStructOut = @import("main.zig").ChainedStructOut;
+const PowerPreference = @import("main.zig").PowerPreference;
+const Texture = @import("texture.zig").Texture;
+
+pub const CacheDeviceDescriptor = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_cache_device_descriptor },
+    isolation_key: [*:0]const u8 = "",
+};
+
+pub const EncoderInternalUsageDescriptor = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_encoder_internal_usage_descriptor },
+    use_internal_usages: Bool32 = .false,
+};
+
+pub const MultisampleStateRenderToSingleSampled = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_multisample_state_render_to_single_sampled },
+    enabled: Bool32 = .false,
+};
+
+pub const RenderPassColorAttachmentRenderToSingleSampled = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_render_pass_color_attachment_render_to_single_sampled },
+    implicit_sample_count: u32 = 1,
+};
+
+pub const TextureInternalUsageDescriptor = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_texture_internal_usage_descriptor },
+    internal_usage: Texture.UsageFlags = Texture.UsageFlags.none,
+};
+
+pub const TogglesDescriptor = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_toggles_descriptor },
+    enabled_toggles_count: usize = 0,
+    enabled_toggles: ?[*]const [*:0]const u8 = null,
+    disabled_toggles_count: usize = 0,
+    disabled_toggles: ?[*]const [*:0]const u8 = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .dawn_toggles_descriptor },
+        enabled_toggles: ?[]const [*:0]const u8 = null,
+        disabled_toggles: ?[]const [*:0]const u8 = null,
+    }) TogglesDescriptor {
+        return .{
+            .chain = v.chain,
+            .enabled_toggles_count = if (v.enabled_toggles) |e| e.len else 0,
+            .enabled_toggles = if (v.enabled_toggles) |e| e.ptr else null,
+            .disabled_toggles_count = if (v.disabled_toggles) |e| e.len else 0,
+            .disabled_toggles = if (v.disabled_toggles) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const ShaderModuleSPIRVOptionsDescriptor = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .dawn_shader_module_spirv_options_descriptor },
+    allow_non_uniform_derivatives: Bool32 = .false,
+};
+
+pub const AdapterPropertiesPowerPreference = extern struct {
+    chain: ChainedStructOut = .{
+        .next = null,
+        .s_type = .dawn_adapter_properties_power_preference,
+    },
+    power_preference: PowerPreference = .undefined,
+};
+
+pub const BufferDescriptorErrorInfoFromWireClient = extern struct {
+    chain: ChainedStruct = .{
+        .next = null,
+        .s_type = .dawn_buffer_descriptor_error_info_from_wire_client,
+    },
+    out_of_memory: Bool32 = .false,
+};

--- a/src/dgpu/device.zig
+++ b/src/dgpu/device.zig
@@ -1,0 +1,368 @@
+const std = @import("std");
+const Adapter = @import("adapter.zig").Adapter;
+const Queue = @import("queue.zig").Queue;
+const BindGroup = @import("bind_group.zig").BindGroup;
+const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+const Buffer = @import("buffer.zig").Buffer;
+const CommandEncoder = @import("command_encoder.zig").CommandEncoder;
+const ComputePipeline = @import("compute_pipeline.zig").ComputePipeline;
+const ExternalTexture = @import("external_texture.zig").ExternalTexture;
+const PipelineLayout = @import("pipeline_layout.zig").PipelineLayout;
+const QuerySet = @import("query_set.zig").QuerySet;
+const RenderBundleEncoder = @import("render_bundle_encoder.zig").RenderBundleEncoder;
+const RenderPipeline = @import("render_pipeline.zig").RenderPipeline;
+const Sampler = @import("sampler.zig").Sampler;
+const ShaderModule = @import("shader_module.zig").ShaderModule;
+const Surface = @import("surface.zig").Surface;
+const SwapChain = @import("swap_chain.zig").SwapChain;
+const Texture = @import("texture.zig").Texture;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const FeatureName = @import("main.zig").FeatureName;
+const RequiredLimits = @import("main.zig").RequiredLimits;
+const SupportedLimits = @import("main.zig").SupportedLimits;
+const ErrorType = @import("main.zig").ErrorType;
+const ErrorFilter = @import("main.zig").ErrorFilter;
+const LoggingType = @import("main.zig").LoggingType;
+const CreatePipelineAsyncStatus = @import("main.zig").CreatePipelineAsyncStatus;
+const LoggingCallback = @import("main.zig").LoggingCallback;
+const ErrorCallback = @import("main.zig").ErrorCallback;
+const CreateComputePipelineAsyncCallback = @import("main.zig").CreateComputePipelineAsyncCallback;
+const CreateRenderPipelineAsyncCallback = @import("main.zig").CreateRenderPipelineAsyncCallback;
+const Impl = @import("interface.zig").Impl;
+const dawn = @import("dawn.zig");
+
+pub const Device = opaque {
+    pub const LostCallback = *const fn (
+        reason: LostReason,
+        message: [*:0]const u8,
+        userdata: ?*anyopaque,
+    ) callconv(.C) void;
+
+    pub const LostReason = enum(u32) {
+        undefined = 0x00000000,
+        destroyed = 0x00000001,
+    };
+
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            dawn_toggles_descriptor: *const dawn.TogglesDescriptor,
+            dawn_cache_device_descriptor: *const dawn.CacheDeviceDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+        required_features_count: usize = 0,
+        required_features: ?[*]const FeatureName = null,
+        required_limits: ?*const RequiredLimits = null,
+        default_queue: Queue.Descriptor = Queue.Descriptor{},
+        device_lost_callback: LostCallback,
+        device_lost_userdata: ?*anyopaque,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: NextInChain = .{ .generic = null },
+            label: ?[*:0]const u8 = null,
+            required_features: ?[]const FeatureName = null,
+            required_limits: ?*const RequiredLimits = null,
+            default_queue: Queue.Descriptor = Queue.Descriptor{},
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .required_features_count = if (v.required_features) |e| e.len else 0,
+                .required_features = if (v.required_features) |e| e.ptr else null,
+                .default_queue = v.default_queue,
+            };
+        }
+    };
+
+    pub inline fn createBindGroup(device: *Device, descriptor: *const BindGroup.Descriptor) *BindGroup {
+        return Impl.deviceCreateBindGroup(device, descriptor);
+    }
+
+    pub inline fn createBindGroupLayout(device: *Device, descriptor: *const BindGroupLayout.Descriptor) *BindGroupLayout {
+        return Impl.deviceCreateBindGroupLayout(device, descriptor);
+    }
+
+    pub inline fn createBuffer(device: *Device, descriptor: *const Buffer.Descriptor) *Buffer {
+        return Impl.deviceCreateBuffer(device, descriptor);
+    }
+
+    pub inline fn createCommandEncoder(device: *Device, descriptor: ?*const CommandEncoder.Descriptor) *CommandEncoder {
+        return Impl.deviceCreateCommandEncoder(device, descriptor);
+    }
+
+    pub inline fn createComputePipeline(device: *Device, descriptor: *const ComputePipeline.Descriptor) *ComputePipeline {
+        return Impl.deviceCreateComputePipeline(device, descriptor);
+    }
+
+    pub inline fn createComputePipelineAsync(
+        device: *Device,
+        descriptor: *const ComputePipeline.Descriptor,
+        context: anytype,
+        comptime callback: fn (
+            status: CreatePipelineAsyncStatus,
+            compute_pipeline: *ComputePipeline,
+            message: [*:0]const u8,
+            ctx: @TypeOf(context),
+        ) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(
+                status: CreatePipelineAsyncStatus,
+                compute_pipeline: *ComputePipeline,
+                message: [*:0]const u8,
+                userdata: ?*anyopaque,
+            ) callconv(.C) void {
+                callback(
+                    status,
+                    compute_pipeline,
+                    message,
+                    if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))),
+                );
+            }
+        };
+        Impl.deviceCreateComputePipelineAsync(device, descriptor, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn createErrorBuffer(device: *Device, descriptor: *const Buffer.Descriptor) *Buffer {
+        return Impl.deviceCreateErrorBuffer(device, descriptor);
+    }
+
+    pub inline fn createErrorExternalTexture(device: *Device) *ExternalTexture {
+        return Impl.deviceCreateErrorExternalTexture(device);
+    }
+
+    pub inline fn createErrorTexture(device: *Device, descriptor: *const Texture.Descriptor) *Texture {
+        return Impl.deviceCreateErrorTexture(device, descriptor);
+    }
+
+    pub inline fn createExternalTexture(device: *Device, external_texture_descriptor: *const ExternalTexture.Descriptor) *ExternalTexture {
+        return Impl.deviceCreateExternalTexture(device, external_texture_descriptor);
+    }
+
+    pub inline fn createPipelineLayout(device: *Device, pipeline_layout_descriptor: *const PipelineLayout.Descriptor) *PipelineLayout {
+        return Impl.deviceCreatePipelineLayout(device, pipeline_layout_descriptor);
+    }
+
+    pub inline fn createQuerySet(device: *Device, descriptor: *const QuerySet.Descriptor) *QuerySet {
+        return Impl.deviceCreateQuerySet(device, descriptor);
+    }
+
+    pub inline fn createRenderBundleEncoder(device: *Device, descriptor: *const RenderBundleEncoder.Descriptor) *RenderBundleEncoder {
+        return Impl.deviceCreateRenderBundleEncoder(device, descriptor);
+    }
+
+    pub inline fn createRenderPipeline(device: *Device, descriptor: *const RenderPipeline.Descriptor) *RenderPipeline {
+        return Impl.deviceCreateRenderPipeline(device, descriptor);
+    }
+
+    pub inline fn createRenderPipelineAsync(
+        device: *Device,
+        descriptor: *const RenderPipeline.Descriptor,
+        context: anytype,
+        comptime callback: fn (
+            ctx: @TypeOf(context),
+            status: CreatePipelineAsyncStatus,
+            pipeline: *RenderPipeline,
+            message: [*:0]const u8,
+        ) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(
+                status: CreatePipelineAsyncStatus,
+                pipeline: *RenderPipeline,
+                message: [*:0]const u8,
+                userdata: ?*anyopaque,
+            ) callconv(.C) void {
+                callback(
+                    if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))),
+                    status,
+                    pipeline,
+                    message,
+                );
+            }
+        };
+        Impl.deviceCreateRenderPipelineAsync(device, descriptor, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn createSampler(device: *Device, descriptor: ?*const Sampler.Descriptor) *Sampler {
+        return Impl.deviceCreateSampler(device, descriptor);
+    }
+
+    pub inline fn createShaderModule(device: *Device, descriptor: *const ShaderModule.Descriptor) *ShaderModule {
+        return Impl.deviceCreateShaderModule(device, descriptor);
+    }
+
+    /// Helper to make createShaderModule invocations slightly nicer.
+    pub inline fn createShaderModuleWGSL(
+        device: *Device,
+        label: ?[*:0]const u8,
+        wgsl_code: [*:0]const u8,
+    ) *ShaderModule {
+        return device.createShaderModule(&ShaderModule.Descriptor{
+            .next_in_chain = .{ .wgsl_descriptor = &.{
+                .code = wgsl_code,
+            } },
+            .label = label,
+        });
+    }
+
+    pub inline fn createSwapChain(device: *Device, surface: ?*Surface, descriptor: *const SwapChain.Descriptor) *SwapChain {
+        return Impl.deviceCreateSwapChain(device, surface, descriptor);
+    }
+
+    pub inline fn createTexture(device: *Device, descriptor: *const Texture.Descriptor) *Texture {
+        return Impl.deviceCreateTexture(device, descriptor);
+    }
+
+    pub inline fn destroy(device: *Device) void {
+        Impl.deviceDestroy(device);
+    }
+
+    /// Call once with null to determine the array length, and again to fetch the feature list.
+    ///
+    /// Consider using the enumerateFeaturesOwned helper.
+    pub inline fn enumerateFeatures(device: *Device, features: ?[*]FeatureName) usize {
+        return Impl.deviceEnumerateFeatures(device, features);
+    }
+
+    /// Enumerates the adapter features, storing the result in an allocated slice which is owned by
+    /// the caller.
+    pub inline fn enumerateFeaturesOwned(device: *Device, allocator: std.mem.Allocator) ![]FeatureName {
+        const count = device.enumerateFeatures(null);
+        var data = try allocator.alloc(FeatureName, count);
+        _ = device.enumerateFeatures(data.ptr);
+        return data;
+    }
+
+    pub inline fn forceLoss(device: *Device, reason: LostReason, message: [*:0]const u8) void {
+        return Impl.deviceForceLoss(device, reason, message);
+    }
+
+    pub inline fn getAdapter(device: *Device) *Adapter {
+        return Impl.deviceGetAdapter(device);
+    }
+
+    pub inline fn getLimits(device: *Device, limits: *SupportedLimits) bool {
+        return Impl.deviceGetLimits(device, limits);
+    }
+
+    pub inline fn getQueue(device: *Device) *Queue {
+        return Impl.deviceGetQueue(device);
+    }
+
+    pub inline fn hasFeature(device: *Device, feature: FeatureName) bool {
+        return Impl.deviceHasFeature(device, feature);
+    }
+
+    pub inline fn injectError(device: *Device, typ: ErrorType, message: [*:0]const u8) void {
+        Impl.deviceInjectError(device, typ, message);
+    }
+
+    pub inline fn popErrorScope(
+        device: *Device,
+        context: anytype,
+        comptime callback: fn (ctx: @TypeOf(context), typ: ErrorType, message: [*:0]const u8) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(typ: ErrorType, message: [*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
+                callback(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), typ, message);
+            }
+        };
+        Impl.devicePopErrorScope(device, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn pushErrorScope(device: *Device, filter: ErrorFilter) void {
+        Impl.devicePushErrorScope(device, filter);
+    }
+
+    pub inline fn setDeviceLostCallback(
+        device: *Device,
+        context: anytype,
+        comptime callback: ?fn (ctx: @TypeOf(context), reason: LostReason, message: [*:0]const u8) callconv(.Inline) void,
+    ) void {
+        if (callback) |cb| {
+            const Context = @TypeOf(context);
+            const Helper = struct {
+                pub fn cCallback(reason: LostReason, message: [*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
+                    cb(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), reason, message);
+                }
+            };
+            Impl.deviceSetDeviceLostCallback(device, Helper.cCallback, if (Context == void) null else context);
+        } else {
+            Impl.deviceSetDeviceLostCallback(device, null, null);
+        }
+    }
+
+    pub inline fn setLabel(device: *Device, label: [*:0]const u8) void {
+        Impl.deviceSetLabel(device, label);
+    }
+
+    pub inline fn setLoggingCallback(
+        device: *Device,
+        context: anytype,
+        comptime callback: ?fn (ctx: @TypeOf(context), typ: LoggingType, message: [*:0]const u8) callconv(.Inline) void,
+    ) void {
+        if (callback) |cb| {
+            const Context = @TypeOf(context);
+            const Helper = struct {
+                pub fn cCallback(typ: LoggingType, message: [*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
+                    cb(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), typ, message);
+                }
+            };
+            Impl.deviceSetLoggingCallback(device, Helper.cCallback, if (Context == void) null else context);
+        } else {
+            Impl.deviceSetLoggingCallback(device, null, null);
+        }
+    }
+
+    pub inline fn setUncapturedErrorCallback(
+        device: *Device,
+        context: anytype,
+        comptime callback: ?fn (ctx: @TypeOf(context), typ: ErrorType, message: [*:0]const u8) callconv(.Inline) void,
+    ) void {
+        if (callback) |cb| {
+            const Context = @TypeOf(context);
+            const Helper = struct {
+                pub fn cCallback(typ: ErrorType, message: [*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
+                    cb(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), typ, message);
+                }
+            };
+            Impl.deviceSetUncapturedErrorCallback(device, Helper.cCallback, if (Context == void) null else context);
+        } else {
+            Impl.deviceSetUncapturedErrorCallback(device, null, null);
+        }
+    }
+
+    pub inline fn tick(device: *Device) void {
+        Impl.deviceTick(device);
+    }
+
+    // Mach WebGPU extension. Supported with mach-gpu-dawn.
+    //
+    // When making Metal interop with other APIs, we need to be careful that QueueSubmit doesn't
+    // mean that the operations will be visible to other APIs/Metal devices right away. macOS
+    // does have a global queue of graphics operations, but the command buffers are inserted there
+    // when they are "scheduled". Submitting other operations before the command buffer is
+    // scheduled could lead to races in who gets scheduled first and incorrect rendering.
+    pub inline fn machWaitForCommandsToBeScheduled(device: *Device) void {
+        Impl.machDeviceWaitForCommandsToBeScheduled(device);
+    }
+
+    pub inline fn validateTextureDescriptor(device: *Device, descriptor: *const Texture.Descriptor) void {
+        Impl.deviceVlidateTextureDescriptor(device, descriptor);
+    }
+
+    pub inline fn reference(device: *Device) void {
+        Impl.deviceReference(device);
+    }
+
+    pub inline fn release(device: *Device) void {
+        Impl.deviceRelease(device);
+    }
+};

--- a/src/dgpu/external_texture.zig
+++ b/src/dgpu/external_texture.zig
@@ -1,0 +1,56 @@
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const TextureView = @import("texture_view.zig").TextureView;
+const Origin2D = @import("main.zig").Origin2D;
+const Extent2D = @import("main.zig").Extent2D;
+const Impl = @import("interface.zig").Impl;
+
+pub const ExternalTexture = opaque {
+    pub const BindingEntry = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .external_texture_binding_entry },
+        external_texture: *ExternalTexture,
+    };
+
+    pub const BindingLayout = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .external_texture_binding_layout },
+    };
+
+    const Rotation = enum(u32) {
+        rotate_0_degrees = 0x00000000,
+        rotate_90_degrees = 0x00000001,
+        rotate_180_degrees = 0x00000002,
+        rotate_270_degrees = 0x00000003,
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        plane0: *TextureView,
+        plane1: ?*TextureView = null,
+        visible_origin: Origin2D,
+        visible_size: Extent2D,
+        do_yuv_to_rgb_conversion_only: Bool32 = .false,
+        yuv_to_rgb_conversion_matrix: ?*const [12]f32 = null,
+        src_transform_function_parameters: *const [7]f32,
+        dst_transform_function_parameters: *const [7]f32,
+        gamut_conversion_matrix: *const [9]f32,
+        flip_y: Bool32,
+        rotation: Rotation,
+    };
+
+    pub inline fn destroy(external_texture: *ExternalTexture) void {
+        Impl.externalTextureDestroy(external_texture);
+    }
+
+    pub inline fn setLabel(external_texture: *ExternalTexture, label: [*:0]const u8) void {
+        Impl.externalTextureSetLabel(external_texture, label);
+    }
+
+    pub inline fn reference(external_texture: *ExternalTexture) void {
+        Impl.externalTextureReference(external_texture);
+    }
+
+    pub inline fn release(external_texture: *ExternalTexture) void {
+        Impl.externalTextureRelease(external_texture);
+    }
+};

--- a/src/dgpu/instance.zig
+++ b/src/dgpu/instance.zig
@@ -1,0 +1,65 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const RequestAdapterStatus = @import("main.zig").RequestAdapterStatus;
+const Surface = @import("surface.zig").Surface;
+const Adapter = @import("adapter.zig").Adapter;
+const RequestAdapterOptions = @import("main.zig").RequestAdapterOptions;
+const RequestAdapterCallback = @import("main.zig").RequestAdapterCallback;
+const Impl = @import("interface.zig").Impl;
+const dawn = @import("dawn.zig");
+
+pub const Instance = opaque {
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            dawn_toggles_descriptor: *const dawn.TogglesDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+    };
+
+    pub inline fn createSurface(instance: *Instance, descriptor: *const Surface.Descriptor) *Surface {
+        return Impl.instanceCreateSurface(instance, descriptor);
+    }
+
+    pub inline fn processEvents(instance: *Instance) void {
+        Impl.instanceProcessEvents(instance);
+    }
+
+    pub inline fn requestAdapter(
+        instance: *Instance,
+        options: ?*const RequestAdapterOptions,
+        context: anytype,
+        comptime callback: fn (
+            ctx: @TypeOf(context),
+            status: RequestAdapterStatus,
+            adapter: ?*Adapter,
+            message: ?[*:0]const u8,
+        ) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(
+                status: RequestAdapterStatus,
+                adapter: ?*Adapter,
+                message: ?[*:0]const u8,
+                userdata: ?*anyopaque,
+            ) callconv(.C) void {
+                callback(
+                    if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))),
+                    status,
+                    adapter,
+                    message,
+                );
+            }
+        };
+        Impl.instanceRequestAdapter(instance, options, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn reference(instance: *Instance) void {
+        Impl.instanceReference(instance);
+    }
+
+    pub inline fn release(instance: *Instance) void {
+        Impl.instanceRelease(instance);
+    }
+};

--- a/src/dgpu/interface.zig
+++ b/src/dgpu/interface.zig
@@ -1,0 +1,2699 @@
+const dgpu = @import("main.zig");
+
+/// The dgpu.Interface implementation that is used by the entire program. Only one may exist, since
+/// it is resolved fully at comptime with no vtable indirection, etc.
+///
+/// Depending on the implementation, it may need to be `.init()`ialized before use.
+pub const Impl = blk: {
+    if (@import("builtin").is_test) {
+        break :blk StubInterface;
+    } else {
+        const root = @import("root");
+        if (!@hasDecl(root, "DGPUInterface")) @compileError("expected to find `pub const DGPUInterface = T;` in root file");
+        _ = dgpu.Interface(root.DGPUInterface); // verify the type
+        break :blk root.DGPUInterface;
+    }
+};
+
+/// Verifies that a dgpu.Interface implementation exposes the expected function declarations.
+pub fn Interface(comptime T: type) type {
+    // // dgpu.Device
+    // assertDecl(T, "deviceCreateRenderPipeline", fn (device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor) callconv(.Inline) *dgpu.RenderPipeline);
+    // assertDecl(T, "deviceCreateRenderPipelineAsync", fn (device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor, callback: dgpu.CreateRenderPipelineAsyncCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "deviceCreatePipelineLayout", fn (device: *dgpu.Device, pipeline_layout_descriptor: *const dgpu.PipelineLayout.Descriptor) callconv(.Inline) *dgpu.PipelineLayout);
+
+    // // dgpu.PipelineLayout
+    // assertDecl(T, "pipelineLayoutSetLabel", fn (pipeline_layout: *dgpu.PipelineLayout, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "pipelineLayoutReference", fn (pipeline_layout: *dgpu.PipelineLayout) callconv(.Inline) void);
+    // assertDecl(T, "pipelineLayoutRelease", fn (pipeline_layout: *dgpu.PipelineLayout) callconv(.Inline) void);
+
+    // // dgpu.RenderBundleEncoder
+    // assertDecl(T, "renderBundleEncoderSetPipeline", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, pipeline: *dgpu.RenderPipeline) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderSetBindGroup", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) callconv(.Inline) void);
+
+    // // dgpu.RenderPassEncoder
+    // assertDecl(T, "renderPassEncoderSetPipeline", fn (render_pass_encoder: *dgpu.RenderPassEncoder, pipeline: *dgpu.RenderPipeline) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetBindGroup", fn (render_pass_encoder: *dgpu.RenderPassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) callconv(.Inline) void);
+
+    // // dgpu.BindGroup
+    // assertDecl(T, "bindGroupSetLabel", fn (bind_group: *dgpu.BindGroup, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "bindGroupReference", fn (bind_group: *dgpu.BindGroup) callconv(.Inline) void);
+    // assertDecl(T, "bindGroupRelease", fn (bind_group: *dgpu.BindGroup) callconv(.Inline) void);
+
+    // // dgpu.BindGroupLayout
+    // assertDecl(T, "bindGroupLayoutSetLabel", fn (bind_group_layout: *dgpu.BindGroupLayout, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "bindGroupLayoutReference", fn (bind_group_layout: *dgpu.BindGroupLayout) callconv(.Inline) void);
+    // assertDecl(T, "bindGroupLayoutRelease", fn (bind_group_layout: *dgpu.BindGroupLayout) callconv(.Inline) void);
+
+    // // dgpu.RenderPipeline
+    // assertDecl(T, "renderPipelineGetBindGroupLayout", fn (render_pipeline: *dgpu.RenderPipeline, group_index: u32) callconv(.Inline) *dgpu.BindGroupLayout);
+    // assertDecl(T, "renderPipelineSetLabel", fn (render_pipeline: *dgpu.RenderPipeline, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderPipelineReference", fn (render_pipeline: *dgpu.RenderPipeline) callconv(.Inline) void);
+    // assertDecl(T, "renderPipelineRelease", fn (render_pipeline: *dgpu.RenderPipeline) callconv(.Inline) void);
+
+    // // dgpu.Instance
+    // assertDecl(T, "createInstance", fn (descriptor: ?*const dgpu.Instance.Descriptor) callconv(.Inline) ?*dgpu.Instance);
+
+    // // dgpu.Adapter
+    // assertDecl(T, "adapterCreateDevice", fn (adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor) callconv(.Inline) ?*dgpu.Device);
+    // assertDecl(T, "adapterEnumerateFeatures", fn (adapter: *dgpu.Adapter, features: ?[*]dgpu.FeatureName) callconv(.Inline) usize);
+    // assertDecl(T, "adapterGetInstance", fn (adapter: *dgpu.Adapter) callconv(.Inline) *dgpu.Instance);
+    // assertDecl(T, "adapterGetLimits", fn (adapter: *dgpu.Adapter, limits: *dgpu.SupportedLimits) callconv(.Inline) u32);
+    // assertDecl(T, "adapterGetProperties", fn (adapter: *dgpu.Adapter, properties: *dgpu.Adapter.Properties) callconv(.Inline) void);
+    // assertDecl(T, "adapterHasFeature", fn (adapter: *dgpu.Adapter, feature: dgpu.FeatureName) callconv(.Inline) u32);
+    // assertDecl(T, "adapterPropertiesFreeMembers", fn (value: dgpu.Adapter.Properties) callconv(.Inline) void);
+    // assertDecl(T, "adapterRequestDevice", fn (adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor, callback: dgpu.RequestDeviceCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "adapterReference", fn (adapter: *dgpu.Adapter) callconv(.Inline) void);
+    // assertDecl(T, "adapterRelease", fn (adapter: *dgpu.Adapter) callconv(.Inline) void);
+
+    // // dgpu.Buffer
+    // assertDecl(T, "bufferDestroy", fn (buffer: *dgpu.Buffer) callconv(.Inline) void);
+    // assertDecl(T, "bufferGetConstMappedRange", fn (buffer: *dgpu.Buffer, offset: usize, size: usize) callconv(.Inline) ?*const anyopaque);
+    // assertDecl(T, "bufferGetMappedRange", fn (buffer: *dgpu.Buffer, offset: usize, size: usize) callconv(.Inline) ?*anyopaque);
+    // assertDecl(T, "bufferGetSize", fn (buffer: *dgpu.Buffer) callconv(.Inline) u64);
+    // assertDecl(T, "bufferGetUsage", fn (buffer: *dgpu.Buffer) callconv(.Inline) dgpu.Buffer.UsageFlags);
+    // assertDecl(T, "bufferMapAsync", fn (buffer: *dgpu.Buffer, mode: dgpu.MapModeFlags, offset: usize, size: usize, callback: dgpu.Buffer.MapCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "bufferSetLabel", fn (buffer: *dgpu.Buffer, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "bufferUnmap", fn (buffer: *dgpu.Buffer) callconv(.Inline) void);
+    // assertDecl(T, "bufferReference", fn (buffer: *dgpu.Buffer) callconv(.Inline) void);
+    // assertDecl(T, "bufferRelease", fn (buffer: *dgpu.Buffer) callconv(.Inline) void);
+
+    // // dgpu.CommandBuffer
+    // assertDecl(T, "commandBufferSetLabel", fn (command_buffer: *dgpu.CommandBuffer, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "commandBufferReference", fn (command_buffer: *dgpu.CommandBuffer) callconv(.Inline) void);
+    // assertDecl(T, "commandBufferRelease", fn (command_buffer: *dgpu.CommandBuffer) callconv(.Inline) void);
+
+    // // dgpu.CommandEncoder
+    // assertDecl(T, "commandEncoderBeginComputePass", fn (command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.ComputePassDescriptor) callconv(.Inline) *dgpu.ComputePassEncoder);
+    // assertDecl(T, "commandEncoderBeginRenderPass", fn (command_encoder: *dgpu.CommandEncoder, descriptor: *const dgpu.RenderPassDescriptor) callconv(.Inline) *dgpu.RenderPassEncoder);
+    // assertDecl(T, "commandEncoderClearBuffer", fn (command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderCopyBufferToBuffer", fn (command_encoder: *dgpu.CommandEncoder, source: *dgpu.Buffer, source_offset: u64, destination: *dgpu.Buffer, destination_offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderCopyBufferToTexture", fn (command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyBuffer, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderCopyTextureToBuffer", fn (command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyBuffer, copy_size: *const dgpu.Extent3D) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderCopyTextureToTexture", fn (command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderFinish", fn (command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.CommandBuffer.Descriptor) callconv(.Inline) *dgpu.CommandBuffer);
+    // assertDecl(T, "commandEncoderInjectValidationError", fn (command_encoder: *dgpu.CommandEncoder, message: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderInsertDebugMarker", fn (command_encoder: *dgpu.CommandEncoder, marker_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderPopDebugGroup", fn (command_encoder: *dgpu.CommandEncoder) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderPushDebugGroup", fn (command_encoder: *dgpu.CommandEncoder, group_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderResolveQuerySet", fn (command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, first_query: u32, query_count: u32, destination: *dgpu.Buffer, destination_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderSetLabel", fn (command_encoder: *dgpu.CommandEncoder, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderWriteBuffer", fn (command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, buffer_offset: u64, data: [*]const u8, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderWriteTimestamp", fn (command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, query_index: u32) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderReference", fn (command_encoder: *dgpu.CommandEncoder) callconv(.Inline) void);
+    // assertDecl(T, "commandEncoderRelease", fn (command_encoder: *dgpu.CommandEncoder) callconv(.Inline) void);
+
+    // // dgpu.ComputePassEncoder
+    // assertDecl(T, "computePassEncoderDispatchWorkgroups", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderDispatchWorkgroupsIndirect", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderEnd", fn (compute_pass_encoder: *dgpu.ComputePassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderInsertDebugMarker", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, marker_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderPopDebugGroup", fn (compute_pass_encoder: *dgpu.ComputePassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderPushDebugGroup", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, group_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderSetBindGroup", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderSetLabel", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderSetPipeline", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, pipeline: *dgpu.ComputePipeline) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderWriteTimestamp", fn (compute_pass_encoder: *dgpu.ComputePassEncoder, query_set: *dgpu.QuerySet, query_index: u32) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderReference", fn (compute_pass_encoder: *dgpu.ComputePassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "computePassEncoderRelease", fn (compute_pass_encoder: *dgpu.ComputePassEncoder) callconv(.Inline) void);
+
+    // // dgpu.ComputePipeline
+    // assertDecl(T, "computePipelineGetBindGroupLayout", fn (compute_pipeline: *dgpu.ComputePipeline, group_index: u32) callconv(.Inline) *dgpu.BindGroupLayout);
+    // assertDecl(T, "computePipelineSetLabel", fn (compute_pipeline: *dgpu.ComputePipeline, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "computePipelineReference", fn (compute_pipeline: *dgpu.ComputePipeline) callconv(.Inline) void);
+    // assertDecl(T, "computePipelineRelease", fn (compute_pipeline: *dgpu.ComputePipeline) callconv(.Inline) void);
+
+    // // dgpu.Device
+    // assertDecl(T, "getProcAddress", fn (device: *dgpu.Device, proc_name: [*:0]const u8) callconv(.Inline) ?dgpu.Proc);
+    // assertDecl(T, "deviceCreateBindGroup", fn (device: *dgpu.Device, descriptor: *const dgpu.BindGroup.Descriptor) callconv(.Inline) *dgpu.BindGroup);
+    // assertDecl(T, "deviceCreateBindGroupLayout", fn (device: *dgpu.Device, descriptor: *const dgpu.BindGroupLayout.Descriptor) callconv(.Inline) *dgpu.BindGroupLayout);
+    // assertDecl(T, "deviceCreateBuffer", fn (device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) callconv(.Inline) *dgpu.Buffer);
+    // assertDecl(T, "deviceCreateCommandEncoder", fn (device: *dgpu.Device, descriptor: ?*const dgpu.CommandEncoder.Descriptor) callconv(.Inline) *dgpu.CommandEncoder);
+    // assertDecl(T, "deviceCreateComputePipeline", fn (device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor) callconv(.Inline) *dgpu.ComputePipeline);
+    // assertDecl(T, "deviceCreateComputePipelineAsync", fn (device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor, callback: dgpu.CreateComputePipelineAsyncCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "deviceCreateErrorBuffer", fn (device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) callconv(.Inline) *dgpu.Buffer);
+    // assertDecl(T, "deviceCreateErrorExternalTexture", fn (device: *dgpu.Device) callconv(.Inline) *dgpu.ExternalTexture);
+    // assertDecl(T, "deviceCreateErrorTexture", fn (device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) callconv(.Inline) *dgpu.Texture);
+    // assertDecl(T, "deviceCreateExternalTexture", fn (device: *dgpu.Device, external_texture_descriptor: *const dgpu.ExternalTexture.Descriptor) callconv(.Inline) *dgpu.ExternalTexture);
+    // assertDecl(T, "deviceCreateQuerySet", fn (device: *dgpu.Device, descriptor: *const dgpu.QuerySet.Descriptor) callconv(.Inline) *dgpu.QuerySet);
+    // assertDecl(T, "deviceCreateRenderBundleEncoder", fn (device: *dgpu.Device, descriptor: *const dgpu.RenderBundleEncoder.Descriptor) callconv(.Inline) *dgpu.RenderBundleEncoder);
+    // // TODO(self-hosted): this cannot be marked as inline for some reason:
+    // // https://github.com/ziglang/zig/issues/12545
+    // assertDecl(T, "deviceCreateSampler", fn (device: *dgpu.Device, descriptor: ?*const dgpu.Sampler.Descriptor) *dgpu.Sampler);
+    // assertDecl(T, "deviceCreateShaderModule", fn (device: *dgpu.Device, descriptor: *const dgpu.ShaderModule.Descriptor) callconv(.Inline) *dgpu.ShaderModule);
+    // assertDecl(T, "deviceCreateSwapChain", fn (device: *dgpu.Device, surface: ?*dgpu.Surface, descriptor: *const dgpu.SwapChain.Descriptor) callconv(.Inline) *dgpu.SwapChain);
+    // assertDecl(T, "deviceCreateTexture", fn (device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) callconv(.Inline) *dgpu.Texture);
+    // assertDecl(T, "deviceDestroy", fn (device: *dgpu.Device) callconv(.Inline) void);
+    // assertDecl(T, "deviceEnumerateFeatures", fn (device: *dgpu.Device, features: ?[*]dgpu.FeatureName) callconv(.Inline) usize);
+    // assertDecl(T, "deviceGetLimits", fn (device: *dgpu.Device, limits: *dgpu.SupportedLimits) callconv(.Inline) u32);
+    // assertDecl(T, "deviceGetQueue", fn (device: *dgpu.Device) callconv(.Inline) *dgpu.Queue);
+    // assertDecl(T, "deviceHasFeature", fn (device: *dgpu.Device, feature: dgpu.FeatureName) callconv(.Inline) u32);
+    // assertDecl(T, "deviceImportSharedFence", fn (device: *dgpu.Device, descriptor: *const dgpu.SharedFence.Descriptor) callconv(.Inline) *dgpu.SharedFence);
+    // assertDecl(T, "deviceImportSharedTextureMemory", fn (device: *dgpu.Device, descriptor: *const dgpu.SharedTextureMemory.Descriptor) callconv(.Inline) *dgpu.SharedTextureMemory);
+    // assertDecl(T, "deviceInjectError", fn (device: *dgpu.Device, typ: dgpu.ErrorType, message: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "devicePopErrorScope", fn (device: *dgpu.Device, callback: dgpu.ErrorCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "devicePushErrorScope", fn (device: *dgpu.Device, filter: dgpu.ErrorFilter) callconv(.Inline) void);
+    // assertDecl(T, "deviceSetDeviceLostCallback", fn (device: *dgpu.Device, callback: ?dgpu.Device.LostCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "deviceSetLabel", fn (device: *dgpu.Device, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "deviceSetLoggingCallback", fn (device: *dgpu.Device, callback: ?dgpu.LoggingCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "deviceSetUncapturedErrorCallback", fn (device: *dgpu.Device, callback: ?dgpu.ErrorCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "deviceTick", fn (device: *dgpu.Device) callconv(.Inline) void);
+    // assertDecl(T, "machDeviceWaitForCommandsToBeScheduled", fn (device: *dgpu.Device) callconv(.Inline) void);
+    // assertDecl(T, "deviceReference", fn (device: *dgpu.Device) callconv(.Inline) void);
+    // assertDecl(T, "deviceRelease", fn (device: *dgpu.Device) callconv(.Inline) void);
+
+    // // dgpu.ExternalTexture
+    // assertDecl(T, "externalTextureDestroy", fn (external_texture: *dgpu.ExternalTexture) callconv(.Inline) void);
+    // assertDecl(T, "externalTextureSetLabel", fn (external_texture: *dgpu.ExternalTexture, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "externalTextureReference", fn (external_texture: *dgpu.ExternalTexture) callconv(.Inline) void);
+    // assertDecl(T, "externalTextureRelease", fn (external_texture: *dgpu.ExternalTexture) callconv(.Inline) void);
+
+    // // dgpu.Instance
+    // assertDecl(T, "instanceCreateSurface", fn (instance: *dgpu.Instance, descriptor: *const dgpu.Surface.Descriptor) callconv(.Inline) *dgpu.Surface);
+    // assertDecl(T, "instanceProcessEvents", fn (instance: *dgpu.Instance) callconv(.Inline) void);
+    // assertDecl(T, "instanceRequestAdapter", fn (instance: *dgpu.Instance, options: ?*const dgpu.RequestAdapterOptions, callback: dgpu.RequestAdapterCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "instanceReference", fn (instance: *dgpu.Instance) callconv(.Inline) void);
+    // assertDecl(T, "instanceRelease", fn (instance: *dgpu.Instance) callconv(.Inline) void);
+
+    // // dgpu.QuerySet
+    // assertDecl(T, "querySetDestroy", fn (query_set: *dgpu.QuerySet) callconv(.Inline) void);
+    // assertDecl(T, "querySetGetCount", fn (query_set: *dgpu.QuerySet) callconv(.Inline) u32);
+    // assertDecl(T, "querySetGetType", fn (query_set: *dgpu.QuerySet) callconv(.Inline) dgpu.QueryType);
+    // assertDecl(T, "querySetSetLabel", fn (query_set: *dgpu.QuerySet, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "querySetReference", fn (query_set: *dgpu.QuerySet) callconv(.Inline) void);
+    // assertDecl(T, "querySetRelease", fn (query_set: *dgpu.QuerySet) callconv(.Inline) void);
+
+    // // dgpu.Queue
+    // assertDecl(T, "queueCopyTextureForBrowser", fn (queue: *dgpu.Queue, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D, options: *const dgpu.CopyTextureForBrowserOptions) callconv(.Inline) void);
+    // assertDecl(T, "queueOnSubmittedWorkDone", fn (queue: *dgpu.Queue, signal_value: u64, callback: dgpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "queueSetLabel", fn (queue: *dgpu.Queue, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "queueSubmit", fn (queue: *dgpu.Queue, command_count: usize, commands: [*]const *const dgpu.CommandBuffer) callconv(.Inline) void);
+    // assertDecl(T, "queueWriteBuffer", fn (queue: *dgpu.Queue, buffer: *dgpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) callconv(.Inline) void);
+    // assertDecl(T, "queueWriteTexture", fn (queue: *dgpu.Queue, destination: *const dgpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const dgpu.Texture.DataLayout, write_size: *const dgpu.Extent3D) callconv(.Inline) void);
+    // assertDecl(T, "queueReference", fn (queue: *dgpu.Queue) callconv(.Inline) void);
+    // assertDecl(T, "queueRelease", fn (queue: *dgpu.Queue) callconv(.Inline) void);
+
+    // // dgpu.RenderBundle
+    // assertDecl(T, "renderBundleSetLabel", fn (render_bundle: *dgpu.RenderBundle, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleReference", fn (render_bundle: *dgpu.RenderBundle) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleRelease", fn (render_bundle: *dgpu.RenderBundle) callconv(.Inline) void);
+
+    // // dgpu.RenderBundleEncoder
+    // assertDecl(T, "renderBundleEncoderDraw", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderDrawIndexed", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderDrawIndexedIndirect", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderDrawIndirect", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderFinish", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, descriptor: ?*const dgpu.RenderBundle.Descriptor) callconv(.Inline) *dgpu.RenderBundle);
+    // assertDecl(T, "renderBundleEncoderInsertDebugMarker", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, marker_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderPopDebugGroup", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderPushDebugGroup", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, group_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderSetIndexBuffer", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderSetLabel", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderSetVertexBuffer", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderReference", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderBundleEncoderRelease", fn (render_bundle_encoder: *dgpu.RenderBundleEncoder) callconv(.Inline) void);
+
+    // // dgpu.RenderPassEncoder
+    // assertDecl(T, "renderPassEncoderBeginOcclusionQuery", fn (render_pass_encoder: *dgpu.RenderPassEncoder, query_index: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderDraw", fn (render_pass_encoder: *dgpu.RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderDrawIndexed", fn (render_pass_encoder: *dgpu.RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderDrawIndexedIndirect", fn (render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderDrawIndirect", fn (render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderEnd", fn (render_pass_encoder: *dgpu.RenderPassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderEndOcclusionQuery", fn (render_pass_encoder: *dgpu.RenderPassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderExecuteBundles", fn (render_pass_encoder: *dgpu.RenderPassEncoder, bundles_count: usize, bundles: [*]const *const dgpu.RenderBundle) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderInsertDebugMarker", fn (render_pass_encoder: *dgpu.RenderPassEncoder, marker_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderPopDebugGroup", fn (render_pass_encoder: *dgpu.RenderPassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderPushDebugGroup", fn (render_pass_encoder: *dgpu.RenderPassEncoder, group_label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetBlendConstant", fn (render_pass_encoder: *dgpu.RenderPassEncoder, color: *const dgpu.Color) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetIndexBuffer", fn (render_pass_encoder: *dgpu.RenderPassEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetLabel", fn (render_pass_encoder: *dgpu.RenderPassEncoder, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetScissorRect", fn (render_pass_encoder: *dgpu.RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetStencilReference", fn (render_pass_encoder: *dgpu.RenderPassEncoder, reference: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetVertexBuffer", fn (render_pass_encoder: *dgpu.RenderPassEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderSetViewport", fn (render_pass_encoder: *dgpu.RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderWriteTimestamp", fn (render_pass_encoder: *dgpu.RenderPassEncoder, query_set: *dgpu.QuerySet, query_index: u32) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderReference", fn (render_pass_encoder: *dgpu.RenderPassEncoder) callconv(.Inline) void);
+    // assertDecl(T, "renderPassEncoderRelease", fn (render_pass_encoder: *dgpu.RenderPassEncoder) callconv(.Inline) void);
+
+    // // dgpu.Sampler
+    // assertDecl(T, "samplerSetLabel", fn (sampler: *dgpu.Sampler, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "samplerReference", fn (sampler: *dgpu.Sampler) callconv(.Inline) void);
+    // assertDecl(T, "samplerRelease", fn (sampler: *dgpu.Sampler) callconv(.Inline) void);
+
+    // // dgpu.ShaderModule
+    // assertDecl(T, "shaderModuleGetCompilationInfo", fn (shader_module: *dgpu.ShaderModule, callback: dgpu.CompilationInfoCallback, userdata: ?*anyopaque) callconv(.Inline) void);
+    // assertDecl(T, "shaderModuleSetLabel", fn (shader_module: *dgpu.ShaderModule, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "shaderModuleReference", fn (shader_module: *dgpu.ShaderModule) callconv(.Inline) void);
+    // assertDecl(T, "shaderModuleRelease", fn (shader_module: *dgpu.ShaderModule) callconv(.Inline) void);
+
+    // // dgpu.SharedFence
+    // assertDecl(T, "sharedFenceExportInfo", fn (shared_fence: *dgpu.SharedFence, info: *dgpu.SharedFence.ExportInfo) callconv(.Inline) void);
+    // assertDecl(T, "sharedFenceReference", fn (shared_fence: *dgpu.SharedFence) callconv(.Inline) void);
+    // assertDecl(T, "sharedFenceRelease", fn (shared_fence: *dgpu.SharedFence) callconv(.Inline) void);
+
+    // // dgpu.SharedTextureMemory
+    // assertDecl(T, "sharedTextureMemoryBeginAccess", fn (shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *const dgpu.SharedTextureMemory.BeginAccessDescriptor) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemoryCreateTexture", fn (shared_texture_memory: *dgpu.SharedTextureMemory, descriptor: *const dgpu.Texture.Descriptor) callconv(.Inline) *dgpu.Texture);
+    // assertDecl(T, "sharedTextureMemoryEndAccess", fn (shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *dgpu.SharedTextureMemory.EndAccessState) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemoryEndAccessStateFreeMembers", fn (value: dgpu.SharedTextureMemory.EndAccessState) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemoryGetProperties", fn (shared_texture_memory: *dgpu.SharedTextureMemory, properties: *dgpu.SharedTextureMemory.Properties) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemorySetLabel", fn (shared_texture_memory: *dgpu.SharedTextureMemory, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemoryReference", fn (shared_texture_memory: *dgpu.SharedTextureMemory) callconv(.Inline) void);
+    // assertDecl(T, "sharedTextureMemoryRelease", fn (shared_texture_memory: *dgpu.SharedTextureMemory) callconv(.Inline) void);
+
+    // // dgpu.Surface
+    // assertDecl(T, "surfaceReference", fn (surface: *dgpu.Surface) callconv(.Inline) void);
+    // assertDecl(T, "surfaceRelease", fn (surface: *dgpu.Surface) callconv(.Inline) void);
+
+    // // dgpu.SwapChain
+    // assertDecl(T, "swapChainGetCurrentTexture", fn (swap_chain: *dgpu.SwapChain) callconv(.Inline) ?*dgpu.Texture);
+    // assertDecl(T, "swapChainGetCurrentTextureView", fn (swap_chain: *dgpu.SwapChain) callconv(.Inline) ?*dgpu.TextureView);
+    // assertDecl(T, "swapChainPresent", fn (swap_chain: *dgpu.SwapChain) callconv(.Inline) void);
+    // assertDecl(T, "swapChainReference", fn (swap_chain: *dgpu.SwapChain) callconv(.Inline) void);
+    // assertDecl(T, "swapChainRelease", fn (swap_chain: *dgpu.SwapChain) callconv(.Inline) void);
+
+    // // dgpu.Texture
+    // assertDecl(T, "textureCreateView", fn (texture: *dgpu.Texture, descriptor: ?*const dgpu.TextureView.Descriptor) callconv(.Inline) *dgpu.TextureView);
+    // assertDecl(T, "textureDestroy", fn (texture: *dgpu.Texture) callconv(.Inline) void);
+    // assertDecl(T, "textureGetDepthOrArrayLayers", fn (texture: *dgpu.Texture) callconv(.Inline) u32);
+    // assertDecl(T, "textureGetDimension", fn (texture: *dgpu.Texture) callconv(.Inline) dgpu.Texture.Dimension);
+    // assertDecl(T, "textureGetFormat", fn (texture: *dgpu.Texture) callconv(.Inline) dgpu.Texture.Format);
+    // assertDecl(T, "textureGetHeight", fn (texture: *dgpu.Texture) callconv(.Inline) u32);
+    // assertDecl(T, "textureGetMipLevelCount", fn (texture: *dgpu.Texture) callconv(.Inline) u32);
+    // assertDecl(T, "textureGetSampleCount", fn (texture: *dgpu.Texture) callconv(.Inline) u32);
+    // assertDecl(T, "textureGetUsage", fn (texture: *dgpu.Texture) callconv(.Inline) dgpu.Texture.UsageFlags);
+    // assertDecl(T, "textureGetWidth", fn (texture: *dgpu.Texture) callconv(.Inline) u32);
+    // assertDecl(T, "textureSetLabel", fn (texture: *dgpu.Texture, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "textureReference", fn (texture: *dgpu.Texture) callconv(.Inline) void);
+    // assertDecl(T, "textureRelease", fn (texture: *dgpu.Texture) callconv(.Inline) void);
+    // assertDecl(T, "textureViewSetLabel", fn (texture_view: *dgpu.TextureView, label: [*:0]const u8) callconv(.Inline) void);
+    // assertDecl(T, "textureViewReference", fn (texture_view: *dgpu.TextureView) callconv(.Inline) void);
+    // assertDecl(T, "textureViewRelease", fn (texture_view: *dgpu.TextureView) callconv(.Inline) void);
+    return T;
+}
+
+fn assertDecl(comptime T: anytype, comptime name: []const u8, comptime Decl: type) void {
+    if (!@hasDecl(T, name)) @compileError("dgpu.Interface missing declaration: " ++ @typeName(Decl));
+    const FoundDecl = @TypeOf(@field(T, name));
+    if (FoundDecl != Decl) @compileError("dgpu.Interface field '" ++ name ++ "'\n\texpected type: " ++ @typeName(Decl) ++ "\n\t   found type: " ++ @typeName(FoundDecl));
+}
+
+/// Exports C ABI function declarations for the given dgpu.Interface implementation.
+pub fn Export(comptime T: type) type {
+    _ = Interface(T); // verify implementation is a valid interface
+    return struct {
+        // // DGPU_EXPORT WGPUInstance dgpuCreateInstance(WGPUInstanceDescriptor const * descriptor);
+        // export fn dgpuCreateInstance(descriptor: ?*const dgpu.Instance.Descriptor) ?*dgpu.Instance {
+        //     return T.createInstance(descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUProc dgpuGetProcAddress(WGPUDevice device, char const * procName);
+        // export fn dgpuGetProcAddress(device: *dgpu.Device, proc_name: [*:0]const u8) ?dgpu.Proc {
+        //     return T.getProcAddress(device, proc_name);
+        // }
+
+        // // DGPU_EXPORT WGPUDevice dgpuAdapterCreateDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor /* nullable */);
+        // export fn dgpuAdapterCreateDevice(adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor) ?*dgpu.Device {
+        //     return T.adapterCreateDevice(adapter, descriptor);
+        // }
+
+        // // DGPU_EXPORT size_t dgpuAdapterEnumerateFeatures(WGPUAdapter adapter, WGPUFeatureName * features);
+        // export fn dgpuAdapterEnumerateFeatures(adapter: *dgpu.Adapter, features: ?[*]dgpu.FeatureName) usize {
+        //     return T.adapterEnumerateFeatures(adapter, features);
+        // }
+
+        // // DGPU_EXPORT WGPUInstance dgpuAdapterGetInstance(WGPUAdapter adapter);
+        // export fn dgpuAdapterGetInstance(adapter: *dgpu.Adapter) *dgpu.Instance {
+        //     return T.adapterGetInstance(adapter);
+        // }
+
+        // // DGPU_EXPORT WGPUBool dgpuAdapterGetLimits(WGPUAdapter adapter, WGPUSupportedLimits * limits);
+        // export fn dgpuAdapterGetLimits(adapter: *dgpu.Adapter, limits: *dgpu.SupportedLimits) u32 {
+        //     return T.adapterGetLimits(adapter, limits);
+        // }
+
+        // // DGPU_EXPORT void dgpuAdapterGetProperties(WGPUAdapter adapter, WGPUAdapterProperties * properties);
+        // export fn dgpuAdapterGetProperties(adapter: *dgpu.Adapter, properties: *dgpu.Adapter.Properties) void {
+        //     return T.adapterGetProperties(adapter, properties);
+        // }
+
+        // // DGPU_EXPORT WGPUBool dgpuAdapterHasFeature(WGPUAdapter adapter, WGPUFeatureName feature);
+        // export fn dgpuAdapterHasFeature(adapter: *dgpu.Adapter, feature: dgpu.FeatureName) u32 {
+        //     return T.adapterHasFeature(adapter, feature);
+        // }
+
+        // // DGPU_EXPORT void dgpuAdapterPropertiesFreeMembers(WGPUAdapterProperties value);
+        // export fn dgpuAdapterPropertiesFreeMembers(value: dgpu.Adapter.Properties) void {
+        //     T.adapterPropertiesFreeMembers(value);
+        // }
+
+        // // DGPU_EXPORT void dgpuAdapterRequestDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor /* nullable */, WGPURequestDeviceCallback callback, void * userdata);
+        // export fn dgpuAdapterRequestDevice(adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor, callback: dgpu.RequestDeviceCallback, userdata: ?*anyopaque) void {
+        //     T.adapterRequestDevice(adapter, descriptor, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuAdapterReference(WGPUAdapter adapter);
+        // export fn dgpuAdapterReference(adapter: *dgpu.Adapter) void {
+        //     T.adapterReference(adapter);
+        // }
+
+        // // DGPU_EXPORT void dgpuAdapterRelease(WGPUAdapter adapter);
+        // export fn dgpuAdapterRelease(adapter: *dgpu.Adapter) void {
+        //     T.adapterRelease(adapter);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupSetLabel(WGPUBindGroup bindGroup, char const * label);
+        // export fn dgpuBindGroupSetLabel(bind_group: *dgpu.BindGroup, label: [*:0]const u8) void {
+        //     T.bindGroupSetLabel(bind_group, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupReference(WGPUBindGroup bindGroup);
+        // export fn dgpuBindGroupReference(bind_group: *dgpu.BindGroup) void {
+        //     T.bindGroupReference(bind_group);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupRelease(WGPUBindGroup bindGroup);
+        // export fn dgpuBindGroupRelease(bind_group: *dgpu.BindGroup) void {
+        //     T.bindGroupRelease(bind_group);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout, char const * label);
+        // export fn dgpuBindGroupLayoutSetLabel(bind_group_layout: *dgpu.BindGroupLayout, label: [*:0]const u8) void {
+        //     T.bindGroupLayoutSetLabel(bind_group_layout, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupLayoutReference(WGPUBindGroupLayout bindGroupLayout);
+        // export fn dgpuBindGroupLayoutReference(bind_group_layout: *dgpu.BindGroupLayout) void {
+        //     T.bindGroupLayoutReference(bind_group_layout);
+        // }
+
+        // // DGPU_EXPORT void dgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout);
+        // export fn dgpuBindGroupLayoutRelease(bind_group_layout: *dgpu.BindGroupLayout) void {
+        //     T.bindGroupLayoutRelease(bind_group_layout);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferDestroy(WGPUBuffer buffer);
+        // export fn dgpuBufferDestroy(buffer: *dgpu.Buffer) void {
+        //     T.bufferDestroy(buffer);
+        // }
+
+        // // DGPU_EXPORT void const * dgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t offset, size_t size);
+        // export fn dgpuBufferGetConstMappedRange(buffer: *dgpu.Buffer, offset: usize, size: usize) ?*const anyopaque {
+        //     return T.bufferGetConstMappedRange(buffer, offset, size);
+        // }
+
+        // // DGPU_EXPORT void * dgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size);
+        // export fn dgpuBufferGetMappedRange(buffer: *dgpu.Buffer, offset: usize, size: usize) ?*anyopaque {
+        //     return T.bufferGetMappedRange(buffer, offset, size);
+        // }
+
+        // // DGPU_EXPORT uint64_t dgpuBufferGetSize(WGPUBuffer buffer);
+        // export fn dgpuBufferGetSize(buffer: *dgpu.Buffer) u64 {
+        //     return T.bufferGetSize(buffer);
+        // }
+
+        // // DGPU_EXPORT WGPUBufferUsage dgpuBufferGetUsage(WGPUBuffer buffer);
+        // export fn dgpuBufferGetUsage(buffer: *dgpu.Buffer) dgpu.Buffer.UsageFlags {
+        //     return T.bufferGetUsage(buffer);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void * userdata);
+        // export fn dgpuBufferMapAsync(buffer: *dgpu.Buffer, mode: u32, offset: usize, size: usize, callback: dgpu.Buffer.MapCallback, userdata: ?*anyopaque) void {
+        //     T.bufferMapAsync(buffer, @as(dgpu.MapModeFlags, @bitCast(mode)), offset, size, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferSetLabel(WGPUBuffer buffer, char const * label);
+        // export fn dgpuBufferSetLabel(buffer: *dgpu.Buffer, label: [*:0]const u8) void {
+        //     T.bufferSetLabel(buffer, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferUnmap(WGPUBuffer buffer);
+        // export fn dgpuBufferUnmap(buffer: *dgpu.Buffer) void {
+        //     T.bufferUnmap(buffer);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferReference(WGPUBuffer buffer);
+        // export fn dgpuBufferReference(buffer: *dgpu.Buffer) void {
+        //     T.bufferReference(buffer);
+        // }
+
+        // // DGPU_EXPORT void dgpuBufferRelease(WGPUBuffer buffer);
+        // export fn dgpuBufferRelease(buffer: *dgpu.Buffer) void {
+        //     T.bufferRelease(buffer);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, char const * label);
+        // export fn dgpuCommandBufferSetLabel(command_buffer: *dgpu.CommandBuffer, label: [*:0]const u8) void {
+        //     T.commandBufferSetLabel(command_buffer, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandBufferReference(WGPUCommandBuffer commandBuffer);
+        // export fn dgpuCommandBufferReference(command_buffer: *dgpu.CommandBuffer) void {
+        //     T.commandBufferReference(command_buffer);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer);
+        // export fn dgpuCommandBufferRelease(command_buffer: *dgpu.CommandBuffer) void {
+        //     T.commandBufferRelease(command_buffer);
+        // }
+
+        // // DGPU_EXPORT WGPUComputePassEncoder dgpuCommandEncoderBeginComputePass(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor /* nullable */);
+        // export fn dgpuCommandEncoderBeginComputePass(command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.ComputePassDescriptor) *dgpu.ComputePassEncoder {
+        //     return T.commandEncoderBeginComputePass(command_encoder, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPURenderPassEncoder dgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor);
+        // export fn dgpuCommandEncoderBeginRenderPass(command_encoder: *dgpu.CommandEncoder, descriptor: *const dgpu.RenderPassDescriptor) *dgpu.RenderPassEncoder {
+        //     return T.commandEncoderBeginRenderPass(command_encoder, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderClearBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size);
+        // export fn dgpuCommandEncoderClearBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+        //     T.commandEncoderClearBuffer(command_encoder, buffer, offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderCopyBufferToBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size);
+        // export fn dgpuCommandEncoderCopyBufferToBuffer(command_encoder: *dgpu.CommandEncoder, source: *dgpu.Buffer, source_offset: u64, destination: *dgpu.Buffer, destination_offset: u64, size: u64) void {
+        //     T.commandEncoderCopyBufferToBuffer(command_encoder, source, source_offset, destination, destination_offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderCopyBufferToTexture(WGPUCommandEncoder commandEncoder, WGPUImageCopyBuffer const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
+        // export fn dgpuCommandEncoderCopyBufferToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyBuffer, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
+        //     T.commandEncoderCopyBufferToTexture(command_encoder, source, destination, copy_size);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderCopyTextureToBuffer(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize);
+        // export fn dgpuCommandEncoderCopyTextureToBuffer(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyBuffer, copy_size: *const dgpu.Extent3D) void {
+        //     T.commandEncoderCopyTextureToBuffer(command_encoder, source, destination, copy_size);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderCopyTextureToTexture(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize);
+        // export fn dgpuCommandEncoderCopyTextureToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
+        //     T.commandEncoderCopyTextureToTexture(command_encoder, source, destination, copy_size);
+        // }
+
+        // // DGPU_EXPORT WGPUCommandBuffer dgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor /* nullable */);
+        // export fn dgpuCommandEncoderFinish(command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.CommandBuffer.Descriptor) *dgpu.CommandBuffer {
+        //     return T.commandEncoderFinish(command_encoder, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderInjectValidationError(WGPUCommandEncoder commandEncoder, char const * message);
+        // export fn dgpuCommandEncoderInjectValidationError(command_encoder: *dgpu.CommandEncoder, message: [*:0]const u8) void {
+        //     T.commandEncoderInjectValidationError(command_encoder, message);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, char const * markerLabel);
+        // export fn dgpuCommandEncoderInsertDebugMarker(command_encoder: *dgpu.CommandEncoder, marker_label: [*:0]const u8) void {
+        //     T.commandEncoderInsertDebugMarker(command_encoder, marker_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder);
+        // export fn dgpuCommandEncoderPopDebugGroup(command_encoder: *dgpu.CommandEncoder) void {
+        //     T.commandEncoderPopDebugGroup(command_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, char const * groupLabel);
+        // export fn dgpuCommandEncoderPushDebugGroup(command_encoder: *dgpu.CommandEncoder, group_label: [*:0]const u8) void {
+        //     T.commandEncoderPushDebugGroup(command_encoder, group_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderResolveQuerySet(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset);
+        // export fn dgpuCommandEncoderResolveQuerySet(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, first_query: u32, query_count: u32, destination: *dgpu.Buffer, destination_offset: u64) void {
+        //     T.commandEncoderResolveQuerySet(command_encoder, query_set, first_query, query_count, destination, destination_offset);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderSetLabel(WGPUCommandEncoder commandEncoder, char const * label);
+        // export fn dgpuCommandEncoderSetLabel(command_encoder: *dgpu.CommandEncoder, label: [*:0]const u8) void {
+        //     T.commandEncoderSetLabel(command_encoder, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderWriteBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t bufferOffset, uint8_t const * data, uint64_t size);
+        // export fn dgpuCommandEncoderWriteBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, buffer_offset: u64, data: [*]const u8, size: u64) void {
+        //     T.commandEncoderWriteBuffer(command_encoder, buffer, buffer_offset, data, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderWriteTimestamp(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+        // export fn dgpuCommandEncoderWriteTimestamp(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+        //     T.commandEncoderWriteTimestamp(command_encoder, query_set, query_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderReference(WGPUCommandEncoder commandEncoder);
+        // export fn dgpuCommandEncoderReference(command_encoder: *dgpu.CommandEncoder) void {
+        //     T.commandEncoderReference(command_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder);
+        // export fn dgpuCommandEncoderRelease(command_encoder: *dgpu.CommandEncoder) void {
+        //     T.commandEncoderRelease(command_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderDispatchWorkgroups(WGPUComputePassEncoder computePassEncoder, uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ);
+        // export fn dgpuComputePassEncoderDispatchWorkgroups(compute_pass_encoder: *dgpu.ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void {
+        //     T.computePassEncoderDispatchWorkgroups(compute_pass_encoder, workgroup_count_x, workgroup_count_y, workgroup_count_z);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderDispatchWorkgroupsIndirect(WGPUComputePassEncoder computePassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
+        // export fn dgpuComputePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder: *dgpu.ComputePassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+        //     T.computePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder, indirect_buffer, indirect_offset);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderEnd(WGPUComputePassEncoder computePassEncoder);
+        // export fn dgpuComputePassEncoderEnd(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+        //     T.computePassEncoderEnd(compute_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder computePassEncoder, char const * markerLabel);
+        // export fn dgpuComputePassEncoderInsertDebugMarker(compute_pass_encoder: *dgpu.ComputePassEncoder, marker_label: [*:0]const u8) void {
+        //     T.computePassEncoderInsertDebugMarker(compute_pass_encoder, marker_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder);
+        // export fn dgpuComputePassEncoderPopDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+        //     T.computePassEncoderPopDebugGroup(compute_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, char const * groupLabel);
+        // export fn dgpuComputePassEncoderPushDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder, group_label: [*:0]const u8) void {
+        //     T.computePassEncoderPushDebugGroup(compute_pass_encoder, group_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets);
+        // export fn dgpuComputePassEncoderSetBindGroup(compute_pass_encoder: *dgpu.ComputePassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+        //     T.computePassEncoderSetBindGroup(compute_pass_encoder, group_index, group, dynamic_offset_count, dynamic_offsets);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, char const * label);
+        // export fn dgpuComputePassEncoderSetLabel(compute_pass_encoder: *dgpu.ComputePassEncoder, label: [*:0]const u8) void {
+        //     T.computePassEncoderSetLabel(compute_pass_encoder, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline);
+        // export fn dgpuComputePassEncoderSetPipeline(compute_pass_encoder: *dgpu.ComputePassEncoder, pipeline: *dgpu.ComputePipeline) void {
+        //     T.computePassEncoderSetPipeline(compute_pass_encoder, pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderWriteTimestamp(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+        // export fn dgpuComputePassEncoderWriteTimestamp(compute_pass_encoder: *dgpu.ComputePassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+        //     T.computePassEncoderWriteTimestamp(compute_pass_encoder, query_set, query_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderReference(WGPUComputePassEncoder computePassEncoder);
+        // export fn dgpuComputePassEncoderReference(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+        //     T.computePassEncoderReference(compute_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePassEncoderRelease(WGPUComputePassEncoder computePassEncoder);
+        // export fn dgpuComputePassEncoderRelease(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+        //     T.computePassEncoderRelease(compute_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT WGPUBindGroupLayout dgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex);
+        // export fn dgpuComputePipelineGetBindGroupLayout(compute_pipeline: *dgpu.ComputePipeline, group_index: u32) *dgpu.BindGroupLayout {
+        //     return T.computePipelineGetBindGroupLayout(compute_pipeline, group_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, char const * label);
+        // export fn dgpuComputePipelineSetLabel(compute_pipeline: *dgpu.ComputePipeline, label: [*:0]const u8) void {
+        //     T.computePipelineSetLabel(compute_pipeline, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePipelineReference(WGPUComputePipeline computePipeline);
+        // export fn dgpuComputePipelineReference(compute_pipeline: *dgpu.ComputePipeline) void {
+        //     T.computePipelineReference(compute_pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuComputePipelineRelease(WGPUComputePipeline computePipeline);
+        // export fn dgpuComputePipelineRelease(compute_pipeline: *dgpu.ComputePipeline) void {
+        //     T.computePipelineRelease(compute_pipeline);
+        // }
+
+        // // DGPU_EXPORT WGPUBindGroup dgpuDeviceCreateBindGroup(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateBindGroup(device: *dgpu.Device, descriptor: *const dgpu.BindGroup.Descriptor) *dgpu.BindGroup {
+        //     return T.deviceCreateBindGroup(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUBindGroupLayout dgpuDeviceCreateBindGroupLayout(WGPUDevice device, WGPUBindGroupLayout.Descriptor const * descriptor);
+        // export fn dgpuDeviceCreateBindGroupLayout(device: *dgpu.Device, descriptor: *const dgpu.BindGroupLayout.Descriptor) *dgpu.BindGroupLayout {
+        //     return T.deviceCreateBindGroupLayout(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUBuffer dgpuDeviceCreateBuffer(WGPUDevice device, WGPUBuffer.Descriptor const * descriptor);
+        // export fn dgpuDeviceCreateBuffer(device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
+        //     return T.deviceCreateBuffer(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUCommandEncoder dgpuDeviceCreateCommandEncoder(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor /* nullable */);
+        // export fn dgpuDeviceCreateCommandEncoder(device: *dgpu.Device, descriptor: ?*const dgpu.CommandEncoder.Descriptor) *dgpu.CommandEncoder {
+        //     return T.deviceCreateCommandEncoder(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUComputePipeline dgpuDeviceCreateComputePipeline(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateComputePipeline(device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor) *dgpu.ComputePipeline {
+        //     return T.deviceCreateComputePipeline(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceCreateComputePipelineAsync(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncCallback callback, void * userdata);
+        // export fn dgpuDeviceCreateComputePipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor, callback: dgpu.CreateComputePipelineAsyncCallback, userdata: ?*anyopaque) void {
+        //     T.deviceCreateComputePipelineAsync(device, descriptor, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT WGPUBuffer dgpuDeviceCreateErrorBuffer(WGPUDevice device, WGPUBufferDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateErrorBuffer(device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
+        //     return T.deviceCreateErrorBuffer(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUExternalTexture dgpuDeviceCreateErrorExternalTexture(WGPUDevice device);
+        // export fn dgpuDeviceCreateErrorExternalTexture(device: *dgpu.Device) *dgpu.ExternalTexture {
+        //     return T.deviceCreateErrorExternalTexture(device);
+        // }
+
+        // // DGPU_EXPORT WGPUTexture dgpuDeviceCreateErrorTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateErrorTexture(device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+        //     return T.deviceCreateErrorTexture(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUExternalTexture dgpuDeviceCreateExternalTexture(WGPUDevice device, WGPUExternalTextureDescriptor const * externalTextureDescriptor);
+        // export fn dgpuDeviceCreateExternalTexture(device: *dgpu.Device, external_texture_descriptor: *const dgpu.ExternalTexture.Descriptor) *dgpu.ExternalTexture {
+        //     return T.deviceCreateExternalTexture(device, external_texture_descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUPipelineLayout dgpuDeviceCreatePipelineLayout(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor);
+        // export fn dgpuDeviceCreatePipelineLayout(device: *dgpu.Device, pipeline_layout_descriptor: *const dgpu.PipelineLayout.Descriptor) *dgpu.PipelineLayout {
+        //     return T.deviceCreatePipelineLayout(device, pipeline_layout_descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUQuerySet dgpuDeviceCreateQuerySet(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateQuerySet(device: *dgpu.Device, descriptor: *const dgpu.QuerySet.Descriptor) *dgpu.QuerySet {
+        //     return T.deviceCreateQuerySet(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPURenderBundleEncoder dgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateRenderBundleEncoder(device: *dgpu.Device, descriptor: *const dgpu.RenderBundleEncoder.Descriptor) *dgpu.RenderBundleEncoder {
+        //     return T.deviceCreateRenderBundleEncoder(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPURenderPipeline dgpuDeviceCreateRenderPipeline(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateRenderPipeline(device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor) *dgpu.RenderPipeline {
+        //     return T.deviceCreateRenderPipeline(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
+        // export fn dgpuDeviceCreateRenderPipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor, callback: dgpu.CreateRenderPipelineAsyncCallback, userdata: ?*anyopaque) void {
+        //     T.deviceCreateRenderPipelineAsync(device, descriptor, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT WGPUSampler dgpuDeviceCreateSampler(WGPUDevice device, WGPUSamplerDescriptor const * descriptor /* nullable */);
+        // export fn dgpuDeviceCreateSampler(device: *dgpu.Device, descriptor: ?*const dgpu.Sampler.Descriptor) *dgpu.Sampler {
+        //     return T.deviceCreateSampler(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUShaderModule dgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateShaderModule(device: *dgpu.Device, descriptor: *const dgpu.ShaderModule.Descriptor) *dgpu.ShaderModule {
+        //     return T.deviceCreateShaderModule(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUSwapChain dgpuDeviceCreateSwapChain(WGPUDevice device, WGPUSurface surface /* nullable */, WGPUSwapChainDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateSwapChain(device: *dgpu.Device, surface: ?*dgpu.Surface, descriptor: *const dgpu.SwapChain.Descriptor) *dgpu.SwapChain {
+        //     return T.deviceCreateSwapChain(device, surface, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUTexture dgpuDeviceCreateTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor);
+        // export fn dgpuDeviceCreateTexture(device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+        //     return T.deviceCreateTexture(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceDestroy(WGPUDevice device);
+        // export fn dgpuDeviceDestroy(device: *dgpu.Device) void {
+        //     T.deviceDestroy(device);
+        // }
+
+        // // DGPU_EXPORT size_t dgpuDeviceEnumerateFeatures(WGPUDevice device, WGPUFeatureName * features);
+        // export fn dgpuDeviceEnumerateFeatures(device: *dgpu.Device, features: ?[*]dgpu.FeatureName) usize {
+        //     return T.deviceEnumerateFeatures(device, features);
+        // }
+
+        // // DGPU_EXPORT WGPUBool dgpuDeviceGetLimits(WGPUDevice device, WGPUSupportedLimits * limits);
+        // export fn dgpuDeviceGetLimits(device: *dgpu.Device, limits: *dgpu.SupportedLimits) u32 {
+        //     return T.deviceGetLimits(device, limits);
+        // }
+
+        // // DGPU_EXPORT WGPUSharedFence dgpuDeviceImportSharedFence(WGPUDevice device, WGPUSharedFenceDescriptor const * descriptor);
+        // export fn dgpuDeviceImportSharedFence(device: *dgpu.Device, descriptor: *const dgpu.SharedFence.Descriptor) *dgpu.SharedFence {
+        //     return T.deviceImportSharedFence(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUSharedTextureMemory dgpuDeviceImportSharedTextureMemory(WGPUDevice device, WGPUSharedTextureMemoryDescriptor const * descriptor);
+        // export fn dgpuDeviceImportSharedTextureMemory(device: *dgpu.Device, descriptor: *const dgpu.SharedTextureMemory.Descriptor) *dgpu.SharedTextureMemory {
+        //     return T.deviceImportSharedTextureMemory(device, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUQueue dgpuDeviceGetQueue(WGPUDevice device);
+        // export fn dgpuDeviceGetQueue(device: *dgpu.Device) *dgpu.Queue {
+        //     return T.deviceGetQueue(device);
+        // }
+
+        // // DGPU_EXPORT bool dgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature);
+        // export fn dgpuDeviceHasFeature(device: *dgpu.Device, feature: dgpu.FeatureName) u32 {
+        //     return T.deviceHasFeature(device, feature);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceInjectError(WGPUDevice device, WGPUErrorType type, char const * message);
+        // export fn dgpuDeviceInjectError(device: *dgpu.Device, typ: dgpu.ErrorType, message: [*:0]const u8) void {
+        //     T.deviceInjectError(device, typ, message);
+        // }
+
+        // // DGPU_EXPORT void dgpuDevicePopErrorScope(WGPUDevice device, WGPUErrorCallback callback, void * userdata);
+        // export fn dgpuDevicePopErrorScope(device: *dgpu.Device, callback: dgpu.ErrorCallback, userdata: ?*anyopaque) void {
+        //     T.devicePopErrorScope(device, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuDevicePushErrorScope(WGPUDevice device, WGPUErrorFilter filter);
+        // export fn dgpuDevicePushErrorScope(device: *dgpu.Device, filter: dgpu.ErrorFilter) void {
+        //     T.devicePushErrorScope(device, filter);
+        // }
+
+        // // TODO: dawn: callback not marked as nullable in dawn.json but in fact is.
+        // // DGPU_EXPORT void dgpuDeviceSetDeviceLostCallback(WGPUDevice device, WGPUDeviceLostCallback callback, void * userdata);
+        // export fn dgpuDeviceSetDeviceLostCallback(device: *dgpu.Device, callback: ?dgpu.Device.LostCallback, userdata: ?*anyopaque) void {
+        //     T.deviceSetDeviceLostCallback(device, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceSetLabel(WGPUDevice device, char const * label);
+        // export fn dgpuDeviceSetLabel(device: *dgpu.Device, label: [*:0]const u8) void {
+        //     T.deviceSetLabel(device, label);
+        // }
+
+        // // TODO: dawn: callback not marked as nullable in dawn.json but in fact is.
+        // // DGPU_EXPORT void dgpuDeviceSetLoggingCallback(WGPUDevice device, WGPULoggingCallback callback, void * userdata);
+        // export fn dgpuDeviceSetLoggingCallback(device: *dgpu.Device, callback: ?dgpu.LoggingCallback, userdata: ?*anyopaque) void {
+        //     T.deviceSetLoggingCallback(device, callback, userdata);
+        // }
+
+        // // TODO: dawn: callback not marked as nullable in dawn.json but in fact is.
+        // // DGPU_EXPORT void dgpuDeviceSetUncapturedErrorCallback(WGPUDevice device, WGPUErrorCallback callback, void * userdata);
+        // export fn dgpuDeviceSetUncapturedErrorCallback(device: *dgpu.Device, callback: ?dgpu.ErrorCallback, userdata: ?*anyopaque) void {
+        //     T.deviceSetUncapturedErrorCallback(device, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceTick(WGPUDevice device);
+        // export fn dgpuDeviceTick(device: *dgpu.Device) void {
+        //     T.deviceTick(device);
+        // }
+
+        // // DGPU_EXPORT void dgpuMachDeviceWaitForCommandsToBeScheduled(WGPUDevice device);
+        // export fn dgpuMachDeviceWaitForCommandsToBeScheduled(device: *dgpu.Device) void {
+        //     T.machDeviceWaitForCommandsToBeScheduled(device);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceReference(WGPUDevice device);
+        // export fn dgpuDeviceReference(device: *dgpu.Device) void {
+        //     T.deviceReference(device);
+        // }
+
+        // // DGPU_EXPORT void dgpuDeviceRelease(WGPUDevice device);
+        // export fn dgpuDeviceRelease(device: *dgpu.Device) void {
+        //     T.deviceRelease(device);
+        // }
+
+        // // DGPU_EXPORT void dgpuExternalTextureDestroy(WGPUExternalTexture externalTexture);
+        // export fn dgpuExternalTextureDestroy(external_texture: *dgpu.ExternalTexture) void {
+        //     T.externalTextureDestroy(external_texture);
+        // }
+
+        // // DGPU_EXPORT void dgpuExternalTextureSetLabel(WGPUExternalTexture externalTexture, char const * label);
+        // export fn dgpuExternalTextureSetLabel(external_texture: *dgpu.ExternalTexture, label: [*:0]const u8) void {
+        //     T.externalTextureSetLabel(external_texture, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuExternalTextureReference(WGPUExternalTexture externalTexture);
+        // export fn dgpuExternalTextureReference(external_texture: *dgpu.ExternalTexture) void {
+        //     T.externalTextureReference(external_texture);
+        // }
+
+        // // DGPU_EXPORT void dgpuExternalTextureRelease(WGPUExternalTexture externalTexture);
+        // export fn dgpuExternalTextureRelease(external_texture: *dgpu.ExternalTexture) void {
+        //     T.externalTextureRelease(external_texture);
+        // }
+
+        // // DGPU_EXPORT WGPUSurface dgpuInstanceCreateSurface(WGPUInstance instance, WGPUSurfaceDescriptor const * descriptor);
+        // export fn dgpuInstanceCreateSurface(instance: *dgpu.Instance, descriptor: *const dgpu.Surface.Descriptor) *dgpu.Surface {
+        //     return T.instanceCreateSurface(instance, descriptor);
+        // }
+
+        // // DGPU_EXPORT void instanceProcessEvents(WGPUInstance instance);
+        // export fn dgpuInstanceProcessEvents(instance: *dgpu.Instance) void {
+        //     T.instanceProcessEvents(instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuInstanceRequestAdapter(WGPUInstance instance, WGPURequestAdapterOptions const * options /* nullable */, WGPURequestAdapterCallback callback, void * userdata);
+        // export fn dgpuInstanceRequestAdapter(instance: *dgpu.Instance, options: ?*const dgpu.RequestAdapterOptions, callback: dgpu.RequestAdapterCallback, userdata: ?*anyopaque) void {
+        //     T.instanceRequestAdapter(instance, options, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuInstanceReference(WGPUInstance instance);
+        // export fn dgpuInstanceReference(instance: *dgpu.Instance) void {
+        //     T.instanceReference(instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuInstanceRelease(WGPUInstance instance);
+        // export fn dgpuInstanceRelease(instance: *dgpu.Instance) void {
+        //     T.instanceRelease(instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, char const * label);
+        // export fn dgpuPipelineLayoutSetLabel(pipeline_layout: *dgpu.PipelineLayout, label: [*:0]const u8) void {
+        //     T.pipelineLayoutSetLabel(pipeline_layout, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuPipelineLayoutReference(WGPUPipelineLayout pipelineLayout);
+        // export fn dgpuPipelineLayoutReference(pipeline_layout: *dgpu.PipelineLayout) void {
+        //     T.pipelineLayoutReference(pipeline_layout);
+        // }
+
+        // // DGPU_EXPORT void dgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout);
+        // export fn dgpuPipelineLayoutRelease(pipeline_layout: *dgpu.PipelineLayout) void {
+        //     T.pipelineLayoutRelease(pipeline_layout);
+        // }
+
+        // // DGPU_EXPORT void dgpuQuerySetDestroy(WGPUQuerySet querySet);
+        // export fn dgpuQuerySetDestroy(query_set: *dgpu.QuerySet) void {
+        //     T.querySetDestroy(query_set);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuQuerySetGetCount(WGPUQuerySet querySet);
+        // export fn dgpuQuerySetGetCount(query_set: *dgpu.QuerySet) u32 {
+        //     return T.querySetGetCount(query_set);
+        // }
+
+        // // DGPU_EXPORT WGPUQueryType dgpuQuerySetGetType(WGPUQuerySet querySet);
+        // export fn dgpuQuerySetGetType(query_set: *dgpu.QuerySet) dgpu.QueryType {
+        //     return T.querySetGetType(query_set);
+        // }
+
+        // // DGPU_EXPORT void dgpuQuerySetSetLabel(WGPUQuerySet querySet, char const * label);
+        // export fn dgpuQuerySetSetLabel(query_set: *dgpu.QuerySet, label: [*:0]const u8) void {
+        //     T.querySetSetLabel(query_set, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuQuerySetReference(WGPUQuerySet querySet);
+        // export fn dgpuQuerySetReference(query_set: *dgpu.QuerySet) void {
+        //     T.querySetReference(query_set);
+        // }
+
+        // // DGPU_EXPORT void dgpuQuerySetRelease(WGPUQuerySet querySet);
+        // export fn dgpuQuerySetRelease(query_set: *dgpu.QuerySet) void {
+        //     T.querySetRelease(query_set);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueCopyTextureForBrowser(WGPUQueue queue, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize, WGPUCopyTextureForBrowserOptions const * options);
+        // export fn dgpuQueueCopyTextureForBrowser(queue: *dgpu.Queue, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D, options: *const dgpu.CopyTextureForBrowserOptions) void {
+        //     T.queueCopyTextureForBrowser(queue, source, destination, copy_size, options);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueOnSubmittedWorkDone(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneCallback callback, void * userdata);
+        // export fn dgpuQueueOnSubmittedWorkDone(queue: *dgpu.Queue, signal_value: u64, callback: dgpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) void {
+        //     T.queueOnSubmittedWorkDone(queue, signal_value, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueSetLabel(WGPUQueue queue, char const * label);
+        // export fn dgpuQueueSetLabel(queue: *dgpu.Queue, label: [*:0]const u8) void {
+        //     T.queueSetLabel(queue, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueSubmit(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
+        // export fn dgpuQueueSubmit(queue: *dgpu.Queue, command_count: usize, commands: [*]const *const dgpu.CommandBuffer) void {
+        //     T.queueSubmit(queue, command_count, commands);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void const * data, size_t size);
+        // export fn dgpuQueueWriteBuffer(queue: *dgpu.Queue, buffer: *dgpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) void {
+        //     T.queueWriteBuffer(queue, buffer, buffer_offset, data, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, void const * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize);
+        // export fn dgpuQueueWriteTexture(queue: *dgpu.Queue, destination: *const dgpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const dgpu.Texture.DataLayout, write_size: *const dgpu.Extent3D) void {
+        //     T.queueWriteTexture(queue, destination, data, data_size, data_layout, write_size);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueReference(WGPUQueue queue);
+        // export fn dgpuQueueReference(queue: *dgpu.Queue) void {
+        //     T.queueReference(queue);
+        // }
+
+        // // DGPU_EXPORT void dgpuQueueRelease(WGPUQueue queue);
+        // export fn dgpuQueueRelease(queue: *dgpu.Queue) void {
+        //     T.queueRelease(queue);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label);
+        // export fn dgpuRenderBundleSetLabel(render_bundle: *dgpu.RenderBundle, label: [*:0]const u8) void {
+        //     T.renderBundleSetLabel(render_bundle, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleReference(WGPURenderBundle renderBundle);
+        // export fn dgpuRenderBundleReference(render_bundle: *dgpu.RenderBundle) void {
+        //     T.renderBundleReference(render_bundle);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleRelease(WGPURenderBundle renderBundle);
+        // export fn dgpuRenderBundleRelease(render_bundle: *dgpu.RenderBundle) void {
+        //     T.renderBundleRelease(render_bundle);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderDraw(WGPURenderBundleEncoder renderBundleEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
+        // export fn dgpuRenderBundleEncoderDraw(render_bundle_encoder: *dgpu.RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+        //     T.renderBundleEncoderDraw(render_bundle_encoder, vertex_count, instance_count, first_vertex, first_instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
+        // export fn dgpuRenderBundleEncoderDrawIndexed(render_bundle_encoder: *dgpu.RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+        //     T.renderBundleEncoderDrawIndexed(render_bundle_encoder, index_count, instance_count, first_index, base_vertex, first_instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
+        // export fn dgpuRenderBundleEncoderDrawIndexedIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+        //     T.renderBundleEncoderDrawIndexedIndirect(render_bundle_encoder, indirect_buffer, indirect_offset);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
+        // export fn dgpuRenderBundleEncoderDrawIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+        //     T.renderBundleEncoderDrawIndirect(render_bundle_encoder, indirect_buffer, indirect_offset);
+        // }
+
+        // // DGPU_EXPORT WGPURenderBundle dgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor /* nullable */);
+        // export fn dgpuRenderBundleEncoderFinish(render_bundle_encoder: *dgpu.RenderBundleEncoder, descriptor: ?*const dgpu.RenderBundle.Descriptor) *dgpu.RenderBundle {
+        //     return T.renderBundleEncoderFinish(render_bundle_encoder, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, char const * markerLabel);
+        // export fn dgpuRenderBundleEncoderInsertDebugMarker(render_bundle_encoder: *dgpu.RenderBundleEncoder, marker_label: [*:0]const u8) void {
+        //     T.renderBundleEncoderInsertDebugMarker(render_bundle_encoder, marker_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder);
+        // export fn dgpuRenderBundleEncoderPopDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+        //     T.renderBundleEncoderPopDebugGroup(render_bundle_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, char const * groupLabel);
+        // export fn dgpuRenderBundleEncoderPushDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_label: [*:0]const u8) void {
+        //     T.renderBundleEncoderPushDebugGroup(render_bundle_encoder, group_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets);
+        // export fn dgpuRenderBundleEncoderSetBindGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+        //     T.renderBundleEncoderSetBindGroup(render_bundle_encoder, group_index, group, dynamic_offset_count, dynamic_offsets);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size);
+        // export fn dgpuRenderBundleEncoderSetIndexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
+        //     T.renderBundleEncoderSetIndexBuffer(render_bundle_encoder, buffer, format, offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, char const * label);
+        // export fn dgpuRenderBundleEncoderSetLabel(render_bundle_encoder: *dgpu.RenderBundleEncoder, label: [*:0]const u8) void {
+        //     T.renderBundleEncoderSetLabel(render_bundle_encoder, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline);
+        // export fn dgpuRenderBundleEncoderSetPipeline(render_bundle_encoder: *dgpu.RenderBundleEncoder, pipeline: *dgpu.RenderPipeline) void {
+        //     T.renderBundleEncoderSetPipeline(render_bundle_encoder, pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderSetVertexBuffer(WGPURenderBundleEncoder renderBundleEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size);
+        // export fn dgpuRenderBundleEncoderSetVertexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+        //     T.renderBundleEncoderSetVertexBuffer(render_bundle_encoder, slot, buffer, offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderReference(WGPURenderBundleEncoder renderBundleEncoder);
+        // export fn dgpuRenderBundleEncoderReference(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+        //     T.renderBundleEncoderReference(render_bundle_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderBundleEncoderRelease(WGPURenderBundleEncoder renderBundleEncoder);
+        // export fn dgpuRenderBundleEncoderRelease(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+        //     T.renderBundleEncoderRelease(render_bundle_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderBeginOcclusionQuery(WGPURenderPassEncoder renderPassEncoder, uint32_t queryIndex);
+        // export fn dgpuRenderPassEncoderBeginOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder, query_index: u32) void {
+        //     T.renderPassEncoderBeginOcclusionQuery(render_pass_encoder, query_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderDraw(WGPURenderPassEncoder renderPassEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
+        // export fn dgpuRenderPassEncoderDraw(render_pass_encoder: *dgpu.RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+        //     T.renderPassEncoderDraw(render_pass_encoder, vertex_count, instance_count, first_vertex, first_instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderDrawIndexed(WGPURenderPassEncoder renderPassEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
+        // export fn dgpuRenderPassEncoderDrawIndexed(render_pass_encoder: *dgpu.RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+        //     T.renderPassEncoderDrawIndexed(render_pass_encoder, index_count, instance_count, first_index, base_vertex, first_instance);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderDrawIndexedIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
+        // export fn dgpuRenderPassEncoderDrawIndexedIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+        //     T.renderPassEncoderDrawIndexedIndirect(render_pass_encoder, indirect_buffer, indirect_offset);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderDrawIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset);
+        // export fn dgpuRenderPassEncoderDrawIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+        //     T.renderPassEncoderDrawIndirect(render_pass_encoder, indirect_buffer, indirect_offset);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder);
+        // export fn dgpuRenderPassEncoderEnd(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+        //     T.renderPassEncoderEnd(render_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderEndOcclusionQuery(WGPURenderPassEncoder renderPassEncoder);
+        // export fn dgpuRenderPassEncoderEndOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+        //     T.renderPassEncoderEndOcclusionQuery(render_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderExecuteBundles(WGPURenderPassEncoder renderPassEncoder, size_t bundleCount, WGPURenderBundle const * bundles);
+        // export fn dgpuRenderPassEncoderExecuteBundles(render_pass_encoder: *dgpu.RenderPassEncoder, bundles_count: usize, bundles: [*]const *const dgpu.RenderBundle) void {
+        //     T.renderPassEncoderExecuteBundles(render_pass_encoder, bundles_count, bundles);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder renderPassEncoder, char const * markerLabel);
+        // export fn dgpuRenderPassEncoderInsertDebugMarker(render_pass_encoder: *dgpu.RenderPassEncoder, marker_label: [*:0]const u8) void {
+        //     T.renderPassEncoderInsertDebugMarker(render_pass_encoder, marker_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderPopDebugGroup(WGPURenderPassEncoder renderPassEncoder);
+        // export fn dgpuRenderPassEncoderPopDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+        //     T.renderPassEncoderPopDebugGroup(render_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel);
+        // export fn dgpuRenderPassEncoderPushDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder, group_label: [*:0]const u8) void {
+        //     T.renderPassEncoderPushDebugGroup(render_pass_encoder, group_label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets);
+        // export fn dgpuRenderPassEncoderSetBindGroup(render_pass_encoder: *dgpu.RenderPassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+        //     T.renderPassEncoderSetBindGroup(render_pass_encoder, group_index, group, dynamic_offset_count, dynamic_offsets);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color);
+        // export fn dgpuRenderPassEncoderSetBlendConstant(render_pass_encoder: *dgpu.RenderPassEncoder, color: *const dgpu.Color) void {
+        //     T.renderPassEncoderSetBlendConstant(render_pass_encoder, color);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size);
+        // export fn dgpuRenderPassEncoderSetIndexBuffer(render_pass_encoder: *dgpu.RenderPassEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
+        //     T.renderPassEncoderSetIndexBuffer(render_pass_encoder, buffer, format, offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, char const * label);
+        // export fn dgpuRenderPassEncoderSetLabel(render_pass_encoder: *dgpu.RenderPassEncoder, label: [*:0]const u8) void {
+        //     T.renderPassEncoderSetLabel(render_pass_encoder, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline);
+        // export fn dgpuRenderPassEncoderSetPipeline(render_pass_encoder: *dgpu.RenderPassEncoder, pipeline: *dgpu.RenderPipeline) void {
+        //     T.renderPassEncoderSetPipeline(render_pass_encoder, pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetScissorRect(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+        // export fn dgpuRenderPassEncoderSetScissorRect(render_pass_encoder: *dgpu.RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) void {
+        //     T.renderPassEncoderSetScissorRect(render_pass_encoder, x, y, width, height);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetStencilReference(WGPURenderPassEncoder renderPassEncoder, uint32_t reference);
+        // export fn dgpuRenderPassEncoderSetStencilReference(render_pass_encoder: *dgpu.RenderPassEncoder, reference: u32) void {
+        //     T.renderPassEncoderSetStencilReference(render_pass_encoder, reference);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetVertexBuffer(WGPURenderPassEncoder renderPassEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size);
+        // export fn dgpuRenderPassEncoderSetVertexBuffer(render_pass_encoder: *dgpu.RenderPassEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+        //     T.renderPassEncoderSetVertexBuffer(render_pass_encoder, slot, buffer, offset, size);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderSetViewport(WGPURenderPassEncoder renderPassEncoder, float x, float y, float width, float height, float minDepth, float maxDepth);
+        // export fn dgpuRenderPassEncoderSetViewport(render_pass_encoder: *dgpu.RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
+        //     T.renderPassEncoderSetViewport(render_pass_encoder, x, y, width, height, min_depth, max_depth);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderWriteTimestamp(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+        // export fn dgpuRenderPassEncoderWriteTimestamp(render_pass_encoder: *dgpu.RenderPassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+        //     T.renderPassEncoderWriteTimestamp(render_pass_encoder, query_set, query_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderReference(WGPURenderPassEncoder renderPassEncoder);
+        // export fn dgpuRenderPassEncoderReference(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+        //     T.renderPassEncoderReference(render_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEncoder);
+        // export fn dgpuRenderPassEncoderRelease(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+        //     T.renderPassEncoderRelease(render_pass_encoder);
+        // }
+
+        // // DGPU_EXPORT WGPUBindGroupLayout dgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex);
+        // export fn dgpuRenderPipelineGetBindGroupLayout(render_pipeline: *dgpu.RenderPipeline, group_index: u32) *dgpu.BindGroupLayout {
+        //     return T.renderPipelineGetBindGroupLayout(render_pipeline, group_index);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, char const * label);
+        // export fn dgpuRenderPipelineSetLabel(render_pipeline: *dgpu.RenderPipeline, label: [*:0]const u8) void {
+        //     T.renderPipelineSetLabel(render_pipeline, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPipelineReference(WGPURenderPipeline renderPipeline);
+        // export fn dgpuRenderPipelineReference(render_pipeline: *dgpu.RenderPipeline) void {
+        //     T.renderPipelineReference(render_pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline);
+        // export fn dgpuRenderPipelineRelease(render_pipeline: *dgpu.RenderPipeline) void {
+        //     T.renderPipelineRelease(render_pipeline);
+        // }
+
+        // // DGPU_EXPORT void dgpuSamplerSetLabel(WGPUSampler sampler, char const * label);
+        // export fn dgpuSamplerSetLabel(sampler: *dgpu.Sampler, label: [*:0]const u8) void {
+        //     T.samplerSetLabel(sampler, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuSamplerReference(WGPUSampler sampler);
+        // export fn dgpuSamplerReference(sampler: *dgpu.Sampler) void {
+        //     T.samplerReference(sampler);
+        // }
+
+        // // DGPU_EXPORT void dgpuSamplerRelease(WGPUSampler sampler);
+        // export fn dgpuSamplerRelease(sampler: *dgpu.Sampler) void {
+        //     T.samplerRelease(sampler);
+        // }
+
+        // // DGPU_EXPORT void dgpuShaderModuleGetCompilationInfo(WGPUShaderModule shaderModule, WGPUCompilationInfoCallback callback, void * userdata);
+        // export fn dgpuShaderModuleGetCompilationInfo(shader_module: *dgpu.ShaderModule, callback: dgpu.CompilationInfoCallback, userdata: ?*anyopaque) void {
+        //     T.shaderModuleGetCompilationInfo(shader_module, callback, userdata);
+        // }
+
+        // // DGPU_EXPORT void dgpuShaderModuleSetLabel(WGPUShaderModule shaderModule, char const * label);
+        // export fn dgpuShaderModuleSetLabel(shader_module: *dgpu.ShaderModule, label: [*:0]const u8) void {
+        //     T.shaderModuleSetLabel(shader_module, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuShaderModuleReference(WGPUShaderModule shaderModule);
+        // export fn dgpuShaderModuleReference(shader_module: *dgpu.ShaderModule) void {
+        //     T.shaderModuleReference(shader_module);
+        // }
+
+        // // DGPU_EXPORT void dgpuShaderModuleRelease(WGPUShaderModule shaderModule);
+        // export fn dgpuShaderModuleRelease(shader_module: *dgpu.ShaderModule) void {
+        //     T.shaderModuleRelease(shader_module);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedFenceExportInfo(WGPUSharedFence sharedFence, WGPUSharedFenceExportInfo * info);
+        // export fn dgpuSharedFenceExportInfo(shared_fence: *dgpu.SharedFence, info: *dgpu.SharedFence.ExportInfo) void {
+        //     T.sharedFenceExportInfo(shared_fence, info);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedFenceReference(WGPUSharedFence sharedFence);
+        // export fn dgpuSharedFenceReference(shared_fence: *dgpu.SharedFence) void {
+        //     T.sharedFenceReference(shared_fence);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedFenceRelease(WGPUSharedFence sharedFence);
+        // export fn dgpuSharedFenceRelease(shared_fence: *dgpu.SharedFence) void {
+        //     T.sharedFenceRelease(shared_fence);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryBeginAccess(WGPUSharedTextureMemory sharedTextureMemory, WGPUTexture texture, WGPUSharedTextureMemoryBeginAccessDescriptor const * descriptor);
+        // export fn dgpuSharedTextureMemoryBeginAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *const dgpu.SharedTextureMemory.BeginAccessDescriptor) void {
+        //     T.sharedTextureMemoryBeginAccess(shared_texture_memory, texture, descriptor);
+        // }
+
+        // // DGPU_EXPORT WGPUTexture dgpuSharedTextureMemoryCreateTexture(WGPUSharedTextureMemory sharedTextureMemory, WGPUTextureDescriptor const * descriptor);
+        // export fn dgpuSharedTextureMemoryCreateTexture(shared_texture_memory: *dgpu.SharedTextureMemory, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+        //     return T.sharedTextureMemoryCreateTexture(shared_texture_memory, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryEndAccess(WGPUSharedTextureMemory sharedTextureMemory, WGPUTexture texture, WGPUSharedTextureMemoryEndAccessState * descriptor);
+        // export fn dgpuSharedTextureMemoryEndAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *dgpu.SharedTextureMemory.EndAccessState) void {
+        //     T.sharedTextureMemoryEndAccess(shared_texture_memory, texture, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryEndAccessStateFreeMembers(WGPUSharedTextureMemoryEndAccessState value);
+        // export fn dgpuSharedTextureMemoryEndAccessStateFreeMembers(value: dgpu.SharedTextureMemory.EndAccessState) void {
+        //     T.sharedTextureMemoryEndAccessStateFreeMembers(value);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryGetProperties(WGPUSharedTextureMemory sharedTextureMemory, WGPUSharedTextureMemoryProperties * properties);
+        // export fn dgpuSharedTextureMemoryGetProperties(shared_texture_memory: *dgpu.SharedTextureMemory, properties: *dgpu.SharedTextureMemory.Properties) void {
+        //     T.sharedTextureMemoryGetProperties(shared_texture_memory, properties);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemorySetLabel(WGPUSharedTextureMemory sharedTextureMemory, char const * label);
+        // export fn dgpuSharedTextureMemorySetLabel(shared_texture_memory: *dgpu.SharedTextureMemory, label: [*:0]const u8) void {
+        //     T.sharedTextureMemorySetLabel(shared_texture_memory, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryReference(WGPUSharedTextureMemory sharedTextureMemory);
+        // export fn dgpuSharedTextureMemoryReference(shared_texture_memory: *dgpu.SharedTextureMemory) void {
+        //     T.sharedTextureMemoryReference(shared_texture_memory);
+        // }
+
+        // // DGPU_EXPORT void dgpuSharedTextureMemoryRelease(WGPUSharedTextureMemory sharedTextureMemory);
+        // export fn dgpuSharedTextureMemoryRelease(shared_texture_memory: *dgpu.SharedTextureMemory) void {
+        //     T.sharedTextureMemoryRelease(shared_texture_memory);
+        // }
+
+        // // DGPU_EXPORT void dgpuSurfaceReference(WGPUSurface surface);
+        // export fn dgpuSurfaceReference(surface: *dgpu.Surface) void {
+        //     T.surfaceReference(surface);
+        // }
+
+        // // DGPU_EXPORT void dgpuSurfaceRelease(WGPUSurface surface);
+        // export fn dgpuSurfaceRelease(surface: *dgpu.Surface) void {
+        //     T.surfaceRelease(surface);
+        // }
+
+        // // DGPU_EXPORT WGPUTexture dgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);
+        // export fn dgpuSwapChainGetCurrentTexture(swap_chain: *dgpu.SwapChain) ?*dgpu.Texture {
+        //     return T.swapChainGetCurrentTexture(swap_chain);
+        // }
+
+        // // DGPU_EXPORT WGPUTextureView dgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain);
+        // export fn dgpuSwapChainGetCurrentTextureView(swap_chain: *dgpu.SwapChain) ?*dgpu.TextureView {
+        //     return T.swapChainGetCurrentTextureView(swap_chain);
+        // }
+
+        // // DGPU_EXPORT void dgpuSwapChainPresent(WGPUSwapChain swapChain);
+        // export fn dgpuSwapChainPresent(swap_chain: *dgpu.SwapChain) void {
+        //     T.swapChainPresent(swap_chain);
+        // }
+
+        // // DGPU_EXPORT void dgpuSwapChainReference(WGPUSwapChain swapChain);
+        // export fn dgpuSwapChainReference(swap_chain: *dgpu.SwapChain) void {
+        //     T.swapChainReference(swap_chain);
+        // }
+
+        // // DGPU_EXPORT void dgpuSwapChainRelease(WGPUSwapChain swapChain);
+        // export fn dgpuSwapChainRelease(swap_chain: *dgpu.SwapChain) void {
+        //     T.swapChainRelease(swap_chain);
+        // }
+
+        // // DGPU_EXPORT WGPUTextureView dgpuTextureCreateView(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor /* nullable */);
+        // export fn dgpuTextureCreateView(texture: *dgpu.Texture, descriptor: ?*const dgpu.TextureView.Descriptor) *dgpu.TextureView {
+        //     return T.textureCreateView(texture, descriptor);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureDestroy(WGPUTexture texture);
+        // export fn dgpuTextureDestroy(texture: *dgpu.Texture) void {
+        //     T.textureDestroy(texture);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuTextureGetDepthOrArrayLayers(WGPUTexture texture);
+        // export fn dgpuTextureGetDepthOrArrayLayers(texture: *dgpu.Texture) u32 {
+        //     return T.textureGetDepthOrArrayLayers(texture);
+        // }
+
+        // // DGPU_EXPORT WGPUTextureDimension dgpuTextureGetDimension(WGPUTexture texture);
+        // export fn dgpuTextureGetDimension(texture: *dgpu.Texture) dgpu.Texture.Dimension {
+        //     return T.textureGetDimension(texture);
+        // }
+
+        // // DGPU_EXPORT WGPUTextureFormat dgpuTextureGetFormat(WGPUTexture texture);
+        // export fn dgpuTextureGetFormat(texture: *dgpu.Texture) dgpu.Texture.Format {
+        //     return T.textureGetFormat(texture);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuTextureGetHeight(WGPUTexture texture);
+        // export fn dgpuTextureGetHeight(texture: *dgpu.Texture) u32 {
+        //     return T.textureGetHeight(texture);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuTextureGetMipLevelCount(WGPUTexture texture);
+        // export fn dgpuTextureGetMipLevelCount(texture: *dgpu.Texture) u32 {
+        //     return T.textureGetMipLevelCount(texture);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuTextureGetSampleCount(WGPUTexture texture);
+        // export fn dgpuTextureGetSampleCount(texture: *dgpu.Texture) u32 {
+        //     return T.textureGetSampleCount(texture);
+        // }
+
+        // // DGPU_EXPORT WGPUTextureUsage dgpuTextureGetUsage(WGPUTexture texture);
+        // export fn dgpuTextureGetUsage(texture: *dgpu.Texture) dgpu.Texture.UsageFlags {
+        //     return T.textureGetUsage(texture);
+        // }
+
+        // // DGPU_EXPORT uint32_t dgpuTextureGetWidth(WGPUTexture texture);
+        // export fn dgpuTextureGetWidth(texture: *dgpu.Texture) u32 {
+        //     return T.textureGetWidth(texture);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureSetLabel(WGPUTexture texture, char const * label);
+        // export fn dgpuTextureSetLabel(texture: *dgpu.Texture, label: [*:0]const u8) void {
+        //     T.textureSetLabel(texture, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureReference(WGPUTexture texture);
+        // export fn dgpuTextureReference(texture: *dgpu.Texture) void {
+        //     T.textureReference(texture);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureRelease(WGPUTexture texture);
+        // export fn dgpuTextureRelease(texture: *dgpu.Texture) void {
+        //     T.textureRelease(texture);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureViewSetLabel(WGPUTextureView textureView, char const * label);
+        // export fn dgpuTextureViewSetLabel(texture_view: *dgpu.TextureView, label: [*:0]const u8) void {
+        //     T.textureViewSetLabel(texture_view, label);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureViewReference(WGPUTextureView textureView);
+        // export fn dgpuTextureViewReference(texture_view: *dgpu.TextureView) void {
+        //     T.textureViewReference(texture_view);
+        // }
+
+        // // DGPU_EXPORT void dgpuTextureViewRelease(WGPUTextureView textureView);
+        // export fn dgpuTextureViewRelease(texture_view: *dgpu.TextureView) void {
+        //     T.textureViewRelease(texture_view);
+        // }
+    };
+}
+
+/// A stub dgpu.Interface in which every function is implemented by `unreachable;`
+pub const StubInterface = Interface(struct {
+    // pub inline fn createInstance(descriptor: ?*const dgpu.Instance.Descriptor) ?*dgpu.Instance {
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn getProcAddress(device: *dgpu.Device, proc_name: [*:0]const u8) ?dgpu.Proc {
+    //     _ = device;
+    //     _ = proc_name;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterCreateDevice(adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor) ?*dgpu.Device {
+    //     _ = adapter;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterEnumerateFeatures(adapter: *dgpu.Adapter, features: ?[*]dgpu.FeatureName) usize {
+    //     _ = adapter;
+    //     _ = features;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterGetInstance(adapter: *dgpu.Adapter) *dgpu.Instance {
+    //     _ = adapter;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterGetLimits(adapter: *dgpu.Adapter, limits: *dgpu.SupportedLimits) u32 {
+    //     _ = adapter;
+    //     _ = limits;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterGetProperties(adapter: *dgpu.Adapter, properties: *dgpu.Adapter.Properties) void {
+    //     _ = adapter;
+    //     _ = properties;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterHasFeature(adapter: *dgpu.Adapter, feature: dgpu.FeatureName) u32 {
+    //     _ = adapter;
+    //     _ = feature;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterPropertiesFreeMembers(value: dgpu.Adapter.Properties) void {
+    //     _ = value;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterRequestDevice(adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor, callback: dgpu.RequestDeviceCallback, userdata: ?*anyopaque) void {
+    //     _ = adapter;
+    //     _ = descriptor;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterReference(adapter: *dgpu.Adapter) void {
+    //     _ = adapter;
+    //     unreachable;
+    // }
+
+    // pub inline fn adapterRelease(adapter: *dgpu.Adapter) void {
+    //     _ = adapter;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupSetLabel(bind_group: *dgpu.BindGroup, label: [*:0]const u8) void {
+    //     _ = bind_group;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupReference(bind_group: *dgpu.BindGroup) void {
+    //     _ = bind_group;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupRelease(bind_group: *dgpu.BindGroup) void {
+    //     _ = bind_group;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupLayoutSetLabel(bind_group_layout: *dgpu.BindGroupLayout, label: [*:0]const u8) void {
+    //     _ = bind_group_layout;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupLayoutReference(bind_group_layout: *dgpu.BindGroupLayout) void {
+    //     _ = bind_group_layout;
+    //     unreachable;
+    // }
+
+    // pub inline fn bindGroupLayoutRelease(bind_group_layout: *dgpu.BindGroupLayout) void {
+    //     _ = bind_group_layout;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferDestroy(buffer: *dgpu.Buffer) void {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // // TODO: dawn: return value not marked as nullable in dawn.json but in fact is.
+    // pub inline fn bufferGetConstMappedRange(buffer: *dgpu.Buffer, offset: usize, size: usize) ?*const anyopaque {
+    //     _ = buffer;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // // TODO: dawn: return value not marked as nullable in dawn.json but in fact is.
+    // pub inline fn bufferGetMappedRange(buffer: *dgpu.Buffer, offset: usize, size: usize) ?*anyopaque {
+    //     _ = buffer;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferGetSize(buffer: *dgpu.Buffer) u64 {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferGetUsage(buffer: *dgpu.Buffer) dgpu.Buffer.UsageFlags {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferMapAsync(buffer: *dgpu.Buffer, mode: dgpu.MapModeFlags, offset: usize, size: usize, callback: dgpu.Buffer.MapCallback, userdata: ?*anyopaque) void {
+    //     _ = buffer;
+    //     _ = mode;
+    //     _ = offset;
+    //     _ = size;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferSetLabel(buffer: *dgpu.Buffer, label: [*:0]const u8) void {
+    //     _ = buffer;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferUnmap(buffer: *dgpu.Buffer) void {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferReference(buffer: *dgpu.Buffer) void {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn bufferRelease(buffer: *dgpu.Buffer) void {
+    //     _ = buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandBufferSetLabel(command_buffer: *dgpu.CommandBuffer, label: [*:0]const u8) void {
+    //     _ = command_buffer;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandBufferReference(command_buffer: *dgpu.CommandBuffer) void {
+    //     _ = command_buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandBufferRelease(command_buffer: *dgpu.CommandBuffer) void {
+    //     _ = command_buffer;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderBeginComputePass(command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.ComputePassDescriptor) *dgpu.ComputePassEncoder {
+    //     _ = command_encoder;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderBeginRenderPass(command_encoder: *dgpu.CommandEncoder, descriptor: *const dgpu.RenderPassDescriptor) *dgpu.RenderPassEncoder {
+    //     _ = command_encoder;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderClearBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+    //     _ = command_encoder;
+    //     _ = buffer;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderCopyBufferToBuffer(command_encoder: *dgpu.CommandEncoder, source: *dgpu.Buffer, source_offset: u64, destination: *dgpu.Buffer, destination_offset: u64, size: u64) void {
+    //     _ = command_encoder;
+    //     _ = source;
+    //     _ = source_offset;
+    //     _ = destination;
+    //     _ = destination_offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderCopyBufferToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyBuffer, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
+    //     _ = command_encoder;
+    //     _ = source;
+    //     _ = destination;
+    //     _ = copy_size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderCopyTextureToBuffer(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyBuffer, copy_size: *const dgpu.Extent3D) void {
+    //     _ = command_encoder;
+    //     _ = source;
+    //     _ = destination;
+    //     _ = copy_size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderCopyTextureToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
+    //     _ = command_encoder;
+    //     _ = source;
+    //     _ = destination;
+    //     _ = copy_size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderFinish(command_encoder: *dgpu.CommandEncoder, descriptor: ?*const dgpu.CommandBuffer.Descriptor) *dgpu.CommandBuffer {
+    //     _ = command_encoder;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderInjectValidationError(command_encoder: *dgpu.CommandEncoder, message: [*:0]const u8) void {
+    //     _ = command_encoder;
+    //     _ = message;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderInsertDebugMarker(command_encoder: *dgpu.CommandEncoder, marker_label: [*:0]const u8) void {
+    //     _ = command_encoder;
+    //     _ = marker_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderPopDebugGroup(command_encoder: *dgpu.CommandEncoder) void {
+    //     _ = command_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderPushDebugGroup(command_encoder: *dgpu.CommandEncoder, group_label: [*:0]const u8) void {
+    //     _ = command_encoder;
+    //     _ = group_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderResolveQuerySet(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, first_query: u32, query_count: u32, destination: *dgpu.Buffer, destination_offset: u64) void {
+    //     _ = command_encoder;
+    //     _ = query_set;
+    //     _ = first_query;
+    //     _ = query_count;
+    //     _ = destination;
+    //     _ = destination_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderSetLabel(command_encoder: *dgpu.CommandEncoder, label: [*:0]const u8) void {
+    //     _ = command_encoder;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderWriteBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, buffer_offset: u64, data: [*]const u8, size: u64) void {
+    //     _ = command_encoder;
+    //     _ = buffer;
+    //     _ = buffer_offset;
+    //     _ = data;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderWriteTimestamp(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+    //     _ = command_encoder;
+    //     _ = query_set;
+    //     _ = query_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderReference(command_encoder: *dgpu.CommandEncoder) void {
+    //     _ = command_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn commandEncoderRelease(command_encoder: *dgpu.CommandEncoder) void {
+    //     _ = command_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderDispatchWorkgroups(compute_pass_encoder: *dgpu.ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void {
+    //     _ = compute_pass_encoder;
+    //     _ = workgroup_count_x;
+    //     _ = workgroup_count_y;
+    //     _ = workgroup_count_z;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder: *dgpu.ComputePassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+    //     _ = compute_pass_encoder;
+    //     _ = indirect_buffer;
+    //     _ = indirect_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderEnd(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+    //     _ = compute_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderInsertDebugMarker(compute_pass_encoder: *dgpu.ComputePassEncoder, marker_label: [*:0]const u8) void {
+    //     _ = compute_pass_encoder;
+    //     _ = marker_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderPopDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+    //     _ = compute_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderPushDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder, group_label: [*:0]const u8) void {
+    //     _ = compute_pass_encoder;
+    //     _ = group_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderSetBindGroup(compute_pass_encoder: *dgpu.ComputePassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+    //     _ = compute_pass_encoder;
+    //     _ = group_index;
+    //     _ = group;
+    //     _ = dynamic_offset_count;
+    //     _ = dynamic_offsets;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderSetLabel(compute_pass_encoder: *dgpu.ComputePassEncoder, label: [*:0]const u8) void {
+    //     _ = compute_pass_encoder;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderSetPipeline(compute_pass_encoder: *dgpu.ComputePassEncoder, pipeline: *dgpu.ComputePipeline) void {
+    //     _ = compute_pass_encoder;
+    //     _ = pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderWriteTimestamp(compute_pass_encoder: *dgpu.ComputePassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+    //     _ = compute_pass_encoder;
+    //     _ = query_set;
+    //     _ = query_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderReference(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+    //     _ = compute_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePassEncoderRelease(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
+    //     _ = compute_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePipelineGetBindGroupLayout(compute_pipeline: *dgpu.ComputePipeline, group_index: u32) *dgpu.BindGroupLayout {
+    //     _ = compute_pipeline;
+    //     _ = group_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePipelineSetLabel(compute_pipeline: *dgpu.ComputePipeline, label: [*:0]const u8) void {
+    //     _ = compute_pipeline;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePipelineReference(compute_pipeline: *dgpu.ComputePipeline) void {
+    //     _ = compute_pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn computePipelineRelease(compute_pipeline: *dgpu.ComputePipeline) void {
+    //     _ = compute_pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateBindGroup(device: *dgpu.Device, descriptor: *const dgpu.BindGroup.Descriptor) *dgpu.BindGroup {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateBindGroupLayout(device: *dgpu.Device, descriptor: *const dgpu.BindGroupLayout.Descriptor) *dgpu.BindGroupLayout {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateBuffer(device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateCommandEncoder(device: *dgpu.Device, descriptor: ?*const dgpu.CommandEncoder.Descriptor) *dgpu.CommandEncoder {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateComputePipeline(device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor) *dgpu.ComputePipeline {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateComputePipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor, callback: dgpu.CreateComputePipelineAsyncCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = descriptor;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateErrorBuffer(device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateErrorExternalTexture(device: *dgpu.Device) *dgpu.ExternalTexture {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateErrorTexture(device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateExternalTexture(device: *dgpu.Device, external_texture_descriptor: *const dgpu.ExternalTexture.Descriptor) *dgpu.ExternalTexture {
+    //     _ = device;
+    //     _ = external_texture_descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreatePipelineLayout(device: *dgpu.Device, pipeline_layout_descriptor: *const dgpu.PipelineLayout.Descriptor) *dgpu.PipelineLayout {
+    //     _ = device;
+    //     _ = pipeline_layout_descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateQuerySet(device: *dgpu.Device, descriptor: *const dgpu.QuerySet.Descriptor) *dgpu.QuerySet {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateRenderBundleEncoder(device: *dgpu.Device, descriptor: *const dgpu.RenderBundleEncoder.Descriptor) *dgpu.RenderBundleEncoder {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateRenderPipeline(device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor) *dgpu.RenderPipeline {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateRenderPipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor, callback: dgpu.CreateRenderPipelineAsyncCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = descriptor;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // // TODO(self-hosted): this cannot be marked as inline for some reason.
+    // // https://github.com/ziglang/zig/issues/12545
+    // pub fn deviceCreateSampler(device: *dgpu.Device, descriptor: ?*const dgpu.Sampler.Descriptor) *dgpu.Sampler {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateShaderModule(device: *dgpu.Device, descriptor: *const dgpu.ShaderModule.Descriptor) *dgpu.ShaderModule {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateSwapChain(device: *dgpu.Device, surface: ?*dgpu.Surface, descriptor: *const dgpu.SwapChain.Descriptor) *dgpu.SwapChain {
+    //     _ = device;
+    //     _ = surface;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceCreateTexture(device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceDestroy(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceEnumerateFeatures(device: *dgpu.Device, features: ?[*]dgpu.FeatureName) usize {
+    //     _ = device;
+    //     _ = features;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceGetLimits(device: *dgpu.Device, limits: *dgpu.SupportedLimits) u32 {
+    //     _ = device;
+    //     _ = limits;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceGetQueue(device: *dgpu.Device) *dgpu.Queue {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceHasFeature(device: *dgpu.Device, feature: dgpu.FeatureName) u32 {
+    //     _ = device;
+    //     _ = feature;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceImportSharedFence(device: *dgpu.Device, descriptor: *const dgpu.SharedFence.Descriptor) *dgpu.SharedFence {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceImportSharedTextureMemory(device: *dgpu.Device, descriptor: *const dgpu.SharedTextureMemory.Descriptor) *dgpu.SharedTextureMemory {
+    //     _ = device;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceInjectError(device: *dgpu.Device, typ: dgpu.ErrorType, message: [*:0]const u8) void {
+    //     _ = device;
+    //     _ = typ;
+    //     _ = message;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceLoseForTesting(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn devicePopErrorScope(device: *dgpu.Device, callback: dgpu.ErrorCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn devicePushErrorScope(device: *dgpu.Device, filter: dgpu.ErrorFilter) void {
+    //     _ = device;
+    //     _ = filter;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceSetDeviceLostCallback(device: *dgpu.Device, callback: ?dgpu.Device.LostCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceSetLabel(device: *dgpu.Device, label: [*:0]const u8) void {
+    //     _ = device;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceSetLoggingCallback(device: *dgpu.Device, callback: ?dgpu.LoggingCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceSetUncapturedErrorCallback(device: *dgpu.Device, callback: ?dgpu.ErrorCallback, userdata: ?*anyopaque) void {
+    //     _ = device;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceTick(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn machDeviceWaitForCommandsToBeScheduled(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceReference(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn deviceRelease(device: *dgpu.Device) void {
+    //     _ = device;
+    //     unreachable;
+    // }
+
+    // pub inline fn externalTextureDestroy(external_texture: *dgpu.ExternalTexture) void {
+    //     _ = external_texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn externalTextureSetLabel(external_texture: *dgpu.ExternalTexture, label: [*:0]const u8) void {
+    //     _ = external_texture;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn externalTextureReference(external_texture: *dgpu.ExternalTexture) void {
+    //     _ = external_texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn externalTextureRelease(external_texture: *dgpu.ExternalTexture) void {
+    //     _ = external_texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn instanceCreateSurface(instance: *dgpu.Instance, descriptor: *const dgpu.Surface.Descriptor) *dgpu.Surface {
+    //     _ = instance;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn instanceProcessEvents(instance: *dgpu.Instance) void {
+    //     _ = instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn instanceRequestAdapter(instance: *dgpu.Instance, options: ?*const dgpu.RequestAdapterOptions, callback: dgpu.RequestAdapterCallback, userdata: ?*anyopaque) void {
+    //     _ = instance;
+    //     _ = options;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn instanceReference(instance: *dgpu.Instance) void {
+    //     _ = instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn instanceRelease(instance: *dgpu.Instance) void {
+    //     _ = instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn pipelineLayoutSetLabel(pipeline_layout: *dgpu.PipelineLayout, label: [*:0]const u8) void {
+    //     _ = pipeline_layout;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn pipelineLayoutReference(pipeline_layout: *dgpu.PipelineLayout) void {
+    //     _ = pipeline_layout;
+    //     unreachable;
+    // }
+
+    // pub inline fn pipelineLayoutRelease(pipeline_layout: *dgpu.PipelineLayout) void {
+    //     _ = pipeline_layout;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetDestroy(query_set: *dgpu.QuerySet) void {
+    //     _ = query_set;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetGetCount(query_set: *dgpu.QuerySet) u32 {
+    //     _ = query_set;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetGetType(query_set: *dgpu.QuerySet) dgpu.QueryType {
+    //     _ = query_set;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetSetLabel(query_set: *dgpu.QuerySet, label: [*:0]const u8) void {
+    //     _ = query_set;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetReference(query_set: *dgpu.QuerySet) void {
+    //     _ = query_set;
+    //     unreachable;
+    // }
+
+    // pub inline fn querySetRelease(query_set: *dgpu.QuerySet) void {
+    //     _ = query_set;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueCopyTextureForBrowser(queue: *dgpu.Queue, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D, options: *const dgpu.CopyTextureForBrowserOptions) void {
+    //     _ = queue;
+    //     _ = source;
+    //     _ = destination;
+    //     _ = copy_size;
+    //     _ = options;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueOnSubmittedWorkDone(queue: *dgpu.Queue, signal_value: u64, callback: dgpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) void {
+    //     _ = queue;
+    //     _ = signal_value;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueSetLabel(queue: *dgpu.Queue, label: [*:0]const u8) void {
+    //     _ = queue;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueSubmit(queue: *dgpu.Queue, command_count: usize, commands: [*]const *const dgpu.CommandBuffer) void {
+    //     _ = queue;
+    //     _ = command_count;
+    //     _ = commands;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueWriteBuffer(queue: *dgpu.Queue, buffer: *dgpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) void {
+    //     _ = queue;
+    //     _ = buffer;
+    //     _ = buffer_offset;
+    //     _ = data;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueWriteTexture(queue: *dgpu.Queue, destination: *const dgpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const dgpu.Texture.DataLayout, write_size: *const dgpu.Extent3D) void {
+    //     _ = queue;
+    //     _ = destination;
+    //     _ = data;
+    //     _ = data_size;
+    //     _ = data_layout;
+    //     _ = write_size;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueReference(queue: *dgpu.Queue) void {
+    //     _ = queue;
+    //     unreachable;
+    // }
+
+    // pub inline fn queueRelease(queue: *dgpu.Queue) void {
+    //     _ = queue;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleSetLabel(render_bundle: *dgpu.RenderBundle, label: [*:0]const u8) void {
+    //     _ = render_bundle;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleReference(render_bundle: *dgpu.RenderBundle) void {
+    //     _ = render_bundle;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleRelease(render_bundle: *dgpu.RenderBundle) void {
+    //     _ = render_bundle;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderDraw(render_bundle_encoder: *dgpu.RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+    //     _ = render_bundle_encoder;
+    //     _ = vertex_count;
+    //     _ = instance_count;
+    //     _ = first_vertex;
+    //     _ = first_instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderDrawIndexed(render_bundle_encoder: *dgpu.RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+    //     _ = render_bundle_encoder;
+    //     _ = index_count;
+    //     _ = instance_count;
+    //     _ = first_index;
+    //     _ = base_vertex;
+    //     _ = first_instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderDrawIndexedIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+    //     _ = render_bundle_encoder;
+    //     _ = indirect_buffer;
+    //     _ = indirect_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderDrawIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+    //     _ = render_bundle_encoder;
+    //     _ = indirect_buffer;
+    //     _ = indirect_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderFinish(render_bundle_encoder: *dgpu.RenderBundleEncoder, descriptor: ?*const dgpu.RenderBundle.Descriptor) *dgpu.RenderBundle {
+    //     _ = render_bundle_encoder;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderInsertDebugMarker(render_bundle_encoder: *dgpu.RenderBundleEncoder, marker_label: [*:0]const u8) void {
+    //     _ = render_bundle_encoder;
+    //     _ = marker_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderPopDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+    //     _ = render_bundle_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderPushDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_label: [*:0]const u8) void {
+    //     _ = render_bundle_encoder;
+    //     _ = group_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderSetBindGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+    //     _ = render_bundle_encoder;
+    //     _ = group_index;
+    //     _ = group;
+    //     _ = dynamic_offset_count;
+    //     _ = dynamic_offsets;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderSetIndexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
+    //     _ = render_bundle_encoder;
+    //     _ = buffer;
+    //     _ = format;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderSetLabel(render_bundle_encoder: *dgpu.RenderBundleEncoder, label: [*:0]const u8) void {
+    //     _ = render_bundle_encoder;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderSetPipeline(render_bundle_encoder: *dgpu.RenderBundleEncoder, pipeline: *dgpu.RenderPipeline) void {
+    //     _ = render_bundle_encoder;
+    //     _ = pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderSetVertexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+    //     _ = render_bundle_encoder;
+    //     _ = slot;
+    //     _ = buffer;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderReference(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+    //     _ = render_bundle_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderBundleEncoderRelease(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
+    //     _ = render_bundle_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderBeginOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder, query_index: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = query_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderDraw(render_pass_encoder: *dgpu.RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = vertex_count;
+    //     _ = instance_count;
+    //     _ = first_vertex;
+    //     _ = first_instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderDrawIndexed(render_pass_encoder: *dgpu.RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = index_count;
+    //     _ = instance_count;
+    //     _ = first_index;
+    //     _ = base_vertex;
+    //     _ = first_instance;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderDrawIndexedIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+    //     _ = render_pass_encoder;
+    //     _ = indirect_buffer;
+    //     _ = indirect_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderDrawIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
+    //     _ = render_pass_encoder;
+    //     _ = indirect_buffer;
+    //     _ = indirect_offset;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderEnd(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+    //     _ = render_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderEndOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+    //     _ = render_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderExecuteBundles(render_pass_encoder: *dgpu.RenderPassEncoder, bundles_count: usize, bundles: [*]const *const dgpu.RenderBundle) void {
+    //     _ = render_pass_encoder;
+    //     _ = bundles_count;
+    //     _ = bundles;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderInsertDebugMarker(render_pass_encoder: *dgpu.RenderPassEncoder, marker_label: [*:0]const u8) void {
+    //     _ = render_pass_encoder;
+    //     _ = marker_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderPopDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+    //     _ = render_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderPushDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder, group_label: [*:0]const u8) void {
+    //     _ = render_pass_encoder;
+    //     _ = group_label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetBindGroup(render_pass_encoder: *dgpu.RenderPassEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = group_index;
+    //     _ = group;
+    //     _ = dynamic_offset_count;
+    //     _ = dynamic_offsets;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetBlendConstant(render_pass_encoder: *dgpu.RenderPassEncoder, color: *const dgpu.Color) void {
+    //     _ = render_pass_encoder;
+    //     _ = color;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetIndexBuffer(render_pass_encoder: *dgpu.RenderPassEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
+    //     _ = render_pass_encoder;
+    //     _ = buffer;
+    //     _ = format;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetLabel(render_pass_encoder: *dgpu.RenderPassEncoder, label: [*:0]const u8) void {
+    //     _ = render_pass_encoder;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetPipeline(render_pass_encoder: *dgpu.RenderPassEncoder, pipeline: *dgpu.RenderPipeline) void {
+    //     _ = render_pass_encoder;
+    //     _ = pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetScissorRect(render_pass_encoder: *dgpu.RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = x;
+    //     _ = y;
+    //     _ = width;
+    //     _ = height;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetStencilReference(render_pass_encoder: *dgpu.RenderPassEncoder, reference: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = reference;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetVertexBuffer(render_pass_encoder: *dgpu.RenderPassEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
+    //     _ = render_pass_encoder;
+    //     _ = slot;
+    //     _ = buffer;
+    //     _ = offset;
+    //     _ = size;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderSetViewport(render_pass_encoder: *dgpu.RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
+    //     _ = render_pass_encoder;
+    //     _ = x;
+    //     _ = y;
+    //     _ = width;
+    //     _ = height;
+    //     _ = min_depth;
+    //     _ = max_depth;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderWriteTimestamp(render_pass_encoder: *dgpu.RenderPassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
+    //     _ = render_pass_encoder;
+    //     _ = query_set;
+    //     _ = query_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderReference(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+    //     _ = render_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPassEncoderRelease(render_pass_encoder: *dgpu.RenderPassEncoder) void {
+    //     _ = render_pass_encoder;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPipelineGetBindGroupLayout(render_pipeline: *dgpu.RenderPipeline, group_index: u32) *dgpu.BindGroupLayout {
+    //     _ = render_pipeline;
+    //     _ = group_index;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPipelineSetLabel(render_pipeline: *dgpu.RenderPipeline, label: [*:0]const u8) void {
+    //     _ = render_pipeline;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPipelineReference(render_pipeline: *dgpu.RenderPipeline) void {
+    //     _ = render_pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn renderPipelineRelease(render_pipeline: *dgpu.RenderPipeline) void {
+    //     _ = render_pipeline;
+    //     unreachable;
+    // }
+
+    // pub inline fn samplerSetLabel(sampler: *dgpu.Sampler, label: [*:0]const u8) void {
+    //     _ = sampler;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn samplerReference(sampler: *dgpu.Sampler) void {
+    //     _ = sampler;
+    //     unreachable;
+    // }
+
+    // pub inline fn samplerRelease(sampler: *dgpu.Sampler) void {
+    //     _ = sampler;
+    //     unreachable;
+    // }
+
+    // pub inline fn shaderModuleGetCompilationInfo(shader_module: *dgpu.ShaderModule, callback: dgpu.CompilationInfoCallback, userdata: ?*anyopaque) void {
+    //     _ = shader_module;
+    //     _ = callback;
+    //     _ = userdata;
+    //     unreachable;
+    // }
+
+    // pub inline fn shaderModuleSetLabel(shader_module: *dgpu.ShaderModule, label: [*:0]const u8) void {
+    //     _ = shader_module;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn shaderModuleReference(shader_module: *dgpu.ShaderModule) void {
+    //     _ = shader_module;
+    //     unreachable;
+    // }
+
+    // pub inline fn shaderModuleRelease(shader_module: *dgpu.ShaderModule) void {
+    //     _ = shader_module;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedFenceExportInfo(shared_fence: *dgpu.SharedFence, info: *dgpu.SharedFence.ExportInfo) void {
+    //     _ = shared_fence;
+    //     _ = info;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedFenceReference(shared_fence: *dgpu.SharedFence) void {
+    //     _ = shared_fence;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedFenceRelease(shared_fence: *dgpu.SharedFence) void {
+    //     _ = shared_fence;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryBeginAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *const dgpu.SharedTextureMemory.BeginAccessDescriptor) void {
+    //     _ = shared_texture_memory;
+    //     _ = texture;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryCreateTexture(shared_texture_memory: *dgpu.SharedTextureMemory, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
+    //     _ = shared_texture_memory;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryEndAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *dgpu.SharedTextureMemory.EndAccessState) void {
+    //     _ = shared_texture_memory;
+    //     _ = texture;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryEndAccessStateFreeMembers(value: dgpu.SharedTextureMemory.EndAccessState) void {
+    //     _ = value;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryGetProperties(shared_texture_memory: *dgpu.SharedTextureMemory, properties: *dgpu.SharedTextureMemory.Properties) void {
+    //     _ = shared_texture_memory;
+    //     _ = properties;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemorySetLabel(shared_texture_memory: *dgpu.SharedTextureMemory, label: [*:0]const u8) void {
+    //     _ = shared_texture_memory;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryReference(shared_texture_memory: *dgpu.SharedTextureMemory) void {
+    //     _ = shared_texture_memory;
+    //     unreachable;
+    // }
+
+    // pub inline fn sharedTextureMemoryRelease(shared_texture_memory: *dgpu.SharedTextureMemory) void {
+    //     _ = shared_texture_memory;
+    //     unreachable;
+    // }
+
+    // pub inline fn surfaceReference(surface: *dgpu.Surface) void {
+    //     _ = surface;
+    //     unreachable;
+    // }
+
+    // pub inline fn surfaceRelease(surface: *dgpu.Surface) void {
+    //     _ = surface;
+    //     unreachable;
+    // }
+
+    // pub inline fn swapChainGetCurrentTexture(swap_chain: *dgpu.SwapChain) ?*dgpu.Texture {
+    //     _ = swap_chain;
+    //     unreachable;
+    // }
+
+    // pub inline fn swapChainGetCurrentTextureView(swap_chain: *dgpu.SwapChain) ?*dgpu.TextureView {
+    //     _ = swap_chain;
+    //     unreachable;
+    // }
+
+    // pub inline fn swapChainPresent(swap_chain: *dgpu.SwapChain) void {
+    //     _ = swap_chain;
+    //     unreachable;
+    // }
+
+    // pub inline fn swapChainReference(swap_chain: *dgpu.SwapChain) void {
+    //     _ = swap_chain;
+    //     unreachable;
+    // }
+
+    // pub inline fn swapChainRelease(swap_chain: *dgpu.SwapChain) void {
+    //     _ = swap_chain;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureCreateView(texture: *dgpu.Texture, descriptor: ?*const dgpu.TextureView.Descriptor) *dgpu.TextureView {
+    //     _ = texture;
+    //     _ = descriptor;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureDestroy(texture: *dgpu.Texture) void {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetDepthOrArrayLayers(texture: *dgpu.Texture) u32 {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetDimension(texture: *dgpu.Texture) dgpu.Texture.Dimension {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetFormat(texture: *dgpu.Texture) dgpu.Texture.Format {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetHeight(texture: *dgpu.Texture) u32 {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetMipLevelCount(texture: *dgpu.Texture) u32 {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetSampleCount(texture: *dgpu.Texture) u32 {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetUsage(texture: *dgpu.Texture) dgpu.Texture.UsageFlags {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureGetWidth(texture: *dgpu.Texture) u32 {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureSetLabel(texture: *dgpu.Texture, label: [*:0]const u8) void {
+    //     _ = texture;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureReference(texture: *dgpu.Texture) void {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureRelease(texture: *dgpu.Texture) void {
+    //     _ = texture;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureViewSetLabel(texture_view: *dgpu.TextureView, label: [*:0]const u8) void {
+    //     _ = texture_view;
+    //     _ = label;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureViewReference(texture_view: *dgpu.TextureView) void {
+    //     _ = texture_view;
+    //     unreachable;
+    // }
+
+    // pub inline fn textureViewRelease(texture_view: *dgpu.TextureView) void {
+    //     _ = texture_view;
+    //     unreachable;
+    // }
+});
+
+test "stub" {
+    _ = StubInterface;
+}

--- a/src/dgpu/main.zig
+++ b/src/dgpu/main.zig
@@ -1,0 +1,35 @@
+pub const wgpu = @import("gpu");
+
+// mach-core and mach-core/examples/dusk/triangle depend on these symbols. We just re-export them
+// for right now, but we could improve/change their APIs as we see fit.
+pub const RenderPipeline = wgpu.RenderPipeline;
+pub const PowerPreference = wgpu.PowerPreference;
+pub const FeatureName = wgpu.FeatureName;
+pub const Limits = wgpu.Limits;
+pub const BackendType = wgpu.BackendType;
+pub const Instance = wgpu.Instance;
+pub const Surface = wgpu.Surface;
+pub const Adapter = wgpu.Adapter;
+pub const Device = wgpu.Device;
+pub const SwapChain = wgpu.SwapChain;
+pub const RequestAdapterStatus = wgpu.RequestAdapterStatus;
+pub const RequestAdapterOptions = wgpu.RequestAdapterOptions;
+pub const RequiredLimits = wgpu.RequiredLimits;
+pub const ErrorType = wgpu.ErrorType;
+pub const Queue = wgpu.Queue;
+pub const BlendState = wgpu.BlendState;
+pub const ColorTargetState = wgpu.ColorTargetState;
+pub const ColorWriteMaskFlags = wgpu.ColorWriteMaskFlags;
+pub const FragmentState = wgpu.FragmentState;
+pub const VertexState = wgpu.VertexState;
+pub const RenderPassColorAttachment = wgpu.RenderPassColorAttachment;
+pub const RenderPassDescriptor = wgpu.RenderPassDescriptor;
+pub const Color = wgpu.Color;
+pub const CommandBuffer = wgpu.CommandBuffer;
+
+// TODO: this should be cleaned up
+pub const createInstance = @import("../main.zig").Impl.createInstance;
+
+pub const Interface = @import("interface.zig").Interface;
+pub const Export = @import("interface.zig").Export;
+pub const StubInterface = @import("interface.zig").StubInterface;

--- a/src/dgpu/main.zig
+++ b/src/dgpu/main.zig
@@ -1,35 +1,1025 @@
-pub const wgpu = @import("gpu");
+const std = @import("std");
+const testing = std.testing;
 
-// mach-core and mach-core/examples/dusk/triangle depend on these symbols. We just re-export them
-// for right now, but we could improve/change their APIs as we see fit.
-pub const RenderPipeline = wgpu.RenderPipeline;
-pub const PowerPreference = wgpu.PowerPreference;
-pub const FeatureName = wgpu.FeatureName;
-pub const Limits = wgpu.Limits;
-pub const BackendType = wgpu.BackendType;
-pub const Instance = wgpu.Instance;
-pub const Surface = wgpu.Surface;
-pub const Adapter = wgpu.Adapter;
-pub const Device = wgpu.Device;
-pub const SwapChain = wgpu.SwapChain;
-pub const RequestAdapterStatus = wgpu.RequestAdapterStatus;
-pub const RequestAdapterOptions = wgpu.RequestAdapterOptions;
-pub const RequiredLimits = wgpu.RequiredLimits;
-pub const ErrorType = wgpu.ErrorType;
-pub const Queue = wgpu.Queue;
-pub const BlendState = wgpu.BlendState;
-pub const ColorTargetState = wgpu.ColorTargetState;
-pub const ColorWriteMaskFlags = wgpu.ColorWriteMaskFlags;
-pub const FragmentState = wgpu.FragmentState;
-pub const VertexState = wgpu.VertexState;
-pub const RenderPassColorAttachment = wgpu.RenderPassColorAttachment;
-pub const RenderPassDescriptor = wgpu.RenderPassDescriptor;
-pub const Color = wgpu.Color;
-pub const CommandBuffer = wgpu.CommandBuffer;
+pub const Adapter = @import("adapter.zig").Adapter;
+pub const BindGroup = @import("bind_group.zig").BindGroup;
+pub const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+pub const Buffer = @import("buffer.zig").Buffer;
+pub const CommandBuffer = @import("command_buffer.zig").CommandBuffer;
+pub const CommandEncoder = @import("command_encoder.zig").CommandEncoder;
+pub const ComputePassEncoder = @import("compute_pass_encoder.zig").ComputePassEncoder;
+pub const ComputePipeline = @import("compute_pipeline.zig").ComputePipeline;
+pub const Device = @import("device.zig").Device;
+pub const ExternalTexture = @import("external_texture.zig").ExternalTexture;
+pub const Instance = @import("instance.zig").Instance;
+pub const PipelineLayout = @import("pipeline_layout.zig").PipelineLayout;
+pub const QuerySet = @import("query_set.zig").QuerySet;
+pub const Queue = @import("queue.zig").Queue;
+pub const RenderBundle = @import("render_bundle.zig").RenderBundle;
+pub const RenderBundleEncoder = @import("render_bundle_encoder.zig").RenderBundleEncoder;
+pub const RenderPassEncoder = @import("render_pass_encoder.zig").RenderPassEncoder;
+pub const RenderPipeline = @import("render_pipeline.zig").RenderPipeline;
+pub const Sampler = @import("sampler.zig").Sampler;
+pub const ShaderModule = @import("shader_module.zig").ShaderModule;
+pub const SharedTextureMemory = @import("shared_texture_memory.zig").SharedTextureMemory;
+pub const SharedFence = @import("shared_fence.zig").SharedFence;
+pub const Surface = @import("surface.zig").Surface;
+pub const SwapChain = @import("swap_chain.zig").SwapChain;
+pub const Texture = @import("texture.zig").Texture;
+pub const TextureView = @import("texture_view.zig").TextureView;
 
-// TODO: this should be cleaned up
-pub const createInstance = @import("../main.zig").Impl.createInstance;
+pub const dawn = @import("dawn.zig");
+const instance = @import("instance.zig");
+const device = @import("device.zig");
+const interface = @import("interface.zig");
 
-pub const Interface = @import("interface.zig").Interface;
-pub const Export = @import("interface.zig").Export;
-pub const StubInterface = @import("interface.zig").StubInterface;
+pub const Impl = interface.Impl;
+pub const StubInterface = interface.StubInterface;
+pub const Export = interface.Export;
+pub const Interface = interface.Interface;
+
+pub inline fn createInstance(descriptor: ?*const instance.Instance.Descriptor) ?*instance.Instance {
+    return Impl.createInstance(descriptor);
+}
+
+pub inline fn getProcAddress(_device: *device.Device, proc_name: [*:0]const u8) ?Proc {
+    return Impl.getProcAddress(_device, proc_name);
+}
+
+pub const array_layer_count_undefined = 0xffffffff;
+pub const copy_stride_undefined = 0xffffffff;
+pub const limit_u32_undefined = 0xffffffff;
+pub const limit_u64_undefined = 0xffffffffffffffff;
+pub const mip_level_count_undefined = 0xffffffff;
+pub const whole_map_size = std.math.maxInt(usize);
+pub const whole_size = 0xffffffffffffffff;
+
+/// Generic function pointer type, used for returning API function pointers. Must be
+/// cast to the right `fn (...) callconv(.C) T` type before use.
+pub const Proc = *const fn () callconv(.C) void;
+
+/// 32-bit unsigned boolean type, as used in webgpu.h
+pub const Bool32 = enum(u32) {
+    false,
+    true,
+
+    pub inline fn from(v: bool) @This() {
+        return if (v) .true else .false;
+    }
+};
+
+pub const ComputePassTimestampWrite = extern struct {
+    query_set: *QuerySet,
+    query_index: u32,
+    location: ComputePassTimestampLocation,
+};
+
+pub const RenderPassDepthStencilAttachment = extern struct {
+    view: *TextureView,
+    depth_load_op: LoadOp = .undefined,
+    depth_store_op: StoreOp = .undefined,
+    depth_clear_value: f32 = 0,
+    depth_read_only: Bool32 = .false,
+    stencil_load_op: LoadOp = .undefined,
+    stencil_store_op: StoreOp = .undefined,
+    stencil_clear_value: u32 = 0,
+    stencil_read_only: Bool32 = .false,
+};
+
+pub const RenderPassTimestampWrite = extern struct {
+    query_set: *QuerySet,
+    query_index: u32,
+    location: RenderPassTimestampLocation,
+};
+
+pub const RequestAdapterOptions = extern struct {
+    pub const NextInChain = extern union {
+        generic: ?*const ChainedStruct,
+        dawn_toggles_descriptor: *const dawn.TogglesDescriptor,
+    };
+
+    next_in_chain: NextInChain = .{ .generic = null },
+    compatible_surface: ?*Surface = null,
+    power_preference: PowerPreference = .undefined,
+    backend_type: BackendType = .undefined,
+    force_fallback_adapter: Bool32 = .false,
+    compatibility_mode: Bool32 = .false,
+};
+
+pub const ComputePassDescriptor = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    label: ?[*:0]const u8 = null,
+    timestamp_write_count: usize = 0,
+    timestamp_writes: ?[*]const ComputePassTimestampWrite = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        timestamp_writes: ?[]const ComputePassTimestampWrite = null,
+    }) ComputePassDescriptor {
+        return .{
+            .next_in_chain = v.next_in_chain,
+            .label = v.label,
+            .timestamp_write_count = if (v.timestamp_writes) |e| e.len else 0,
+            .timestamp_writes = if (v.timestamp_writes) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const RenderPassDescriptor = extern struct {
+    pub const NextInChain = extern union {
+        generic: ?*const ChainedStruct,
+        max_draw_count: *const RenderPassDescriptorMaxDrawCount,
+    };
+
+    next_in_chain: NextInChain = .{ .generic = null },
+    label: ?[*:0]const u8 = null,
+    color_attachment_count: usize = 0,
+    color_attachments: ?[*]const RenderPassColorAttachment = null,
+    depth_stencil_attachment: ?*const RenderPassDepthStencilAttachment = null,
+    occlusion_query_set: ?*QuerySet = null,
+    timestamp_write_count: usize = 0,
+    timestamp_writes: ?[*]const RenderPassTimestampWrite = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+        color_attachments: ?[]const RenderPassColorAttachment = null,
+        depth_stencil_attachment: ?*const RenderPassDepthStencilAttachment = null,
+        occlusion_query_set: ?*QuerySet = null,
+        timestamp_writes: ?[]const RenderPassTimestampWrite = null,
+    }) RenderPassDescriptor {
+        return .{
+            .next_in_chain = v.next_in_chain,
+            .label = v.label,
+            .color_attachment_count = if (v.color_attachments) |e| e.len else 0,
+            .color_attachments = if (v.color_attachments) |e| e.ptr else null,
+            .depth_stencil_attachment = v.depth_stencil_attachment,
+            .occlusion_query_set = v.occlusion_query_set,
+            .timestamp_write_count = if (v.timestamp_writes) |e| e.len else 0,
+            .timestamp_writes = if (v.timestamp_writes) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const AlphaMode = enum(u32) { premultiplied = 0x00000000, unpremultiplied = 0x00000001, opaq = 0x00000002 };
+
+pub const BackendType = enum(u32) {
+    undefined,
+    null,
+    webgpu,
+    d3d11,
+    d3d12,
+    metal,
+    vulkan,
+    opengl,
+    opengles,
+
+    pub fn name(t: BackendType) []const u8 {
+        return switch (t) {
+            .undefined => "Undefined",
+            .null => "Null",
+            .webgpu => "WebGPU",
+            .d3d11 => "D3D11",
+            .d3d12 => "D3D12",
+            .metal => "Metal",
+            .vulkan => "Vulkan",
+            .opengl => "OpenGL",
+            .opengles => "OpenGLES",
+        };
+    }
+};
+
+pub const BlendFactor = enum(u32) {
+    zero = 0x00000000,
+    one = 0x00000001,
+    src = 0x00000002,
+    one_minus_src = 0x00000003,
+    src_alpha = 0x00000004,
+    one_minus_src_alpha = 0x00000005,
+    dst = 0x00000006,
+    one_minus_dst = 0x00000007,
+    dst_alpha = 0x00000008,
+    one_minus_dst_alpha = 0x00000009,
+    src_alpha_saturated = 0x0000000A,
+    constant = 0x0000000B,
+    one_minus_constant = 0x0000000C,
+    src1 = 0x0000000D,
+    one_minus_src1 = 0x0000000E,
+    src1_alpha = 0x0000000F,
+    one_minus_src1_alpha = 0x00000010,
+};
+
+pub const BlendOperation = enum(u32) {
+    add = 0x00000000,
+    subtract = 0x00000001,
+    reverse_subtract = 0x00000002,
+    min = 0x00000003,
+    max = 0x00000004,
+};
+
+pub const CompareFunction = enum(u32) {
+    undefined = 0x00000000,
+    never = 0x00000001,
+    less = 0x00000002,
+    less_equal = 0x00000003,
+    greater = 0x00000004,
+    greater_equal = 0x00000005,
+    equal = 0x00000006,
+    not_equal = 0x00000007,
+    always = 0x00000008,
+};
+
+pub const CompilationInfoRequestStatus = enum(u32) {
+    success = 0x00000000,
+    err = 0x00000001,
+    device_lost = 0x00000002,
+    unknown = 0x00000003,
+};
+
+pub const CompilationMessageType = enum(u32) {
+    err = 0x00000000,
+    warning = 0x00000001,
+    info = 0x00000002,
+};
+
+pub const ComputePassTimestampLocation = enum(u32) {
+    beginning = 0x00000000,
+    end = 0x00000001,
+};
+
+pub const CreatePipelineAsyncStatus = enum(u32) {
+    success = 0x00000000,
+    validation_error = 0x00000001,
+    internal_error = 0x00000002,
+    device_lost = 0x00000003,
+    device_destroyed = 0x00000004,
+    unknown = 0x00000005,
+};
+
+pub const CullMode = enum(u32) {
+    none = 0x00000000,
+    front = 0x00000001,
+    back = 0x00000002,
+};
+
+pub const ErrorFilter = enum(u32) {
+    validation = 0x00000000,
+    out_of_memory = 0x00000001,
+    internal = 0x00000002,
+};
+
+pub const ErrorType = enum(u32) {
+    no_error = 0x00000000,
+    validation = 0x00000001,
+    out_of_memory = 0x00000002,
+    internal = 0x00000003,
+    unknown = 0x00000004,
+    device_lost = 0x00000005,
+};
+
+pub const FeatureName = enum(u32) {
+    undefined = 0x00000000,
+    depth_clip_control = 0x00000001,
+    depth32_float_stencil8 = 0x00000002,
+    timestamp_query = 0x00000003,
+    pipeline_statistics_query = 0x00000004,
+    texture_compression_bc = 0x00000005,
+    texture_compression_etc2 = 0x00000006,
+    texture_compression_astc = 0x00000007,
+    indirect_first_instance = 0x00000008,
+    shader_f16 = 0x00000009,
+    rg11_b10_ufloat_renderable = 0x0000000A,
+    bgra8_unorm_storage = 0x0000000B,
+    float32_filterable = 0x0000000C,
+    dawn_internal_usages = 0x000003ea,
+    dawn_multi_planar_formats = 0x000003eb,
+    dawn_native = 0x000003ec,
+    chromium_experimental_dp4a = 0x000003ed,
+    timestamp_query_inside_passes = 0x000003EE,
+    implicit_device_synchronization = 0x000003EF,
+    surface_capabilities = 0x000003F0,
+    transient_attachments = 0x000003F1,
+    msaa_render_to_single_sampled = 0x000003F2,
+    dual_source_blending = 0x000003F3,
+    d3d11_multithread_protected = 0x000003F4,
+    anglet_exture_sharing = 0x000003F5,
+    shared_texture_memory_vk_image_descriptor = 0x0000044C,
+    shared_texture_memory_vk_dedicated_allocation_descriptor = 0x0000044D,
+    shared_texture_memory_a_hardware_buffer_descriptor = 0x0000044_E,
+    shared_texture_memory_dma_buf_descriptor = 0x0000044F,
+    shared_texture_memory_opaque_fd_descriptor = 0x00000450,
+    shared_texture_memory_zircon_handle_descriptor = 0x00000451,
+    shared_texture_memory_dxgi_shared_handle_descriptor = 0x00000452,
+    shared_texture_memory_d3_d11_texture2_d_descriptor = 0x00000453,
+    shared_texture_memory_io_surface_descriptor = 0x00000454,
+    shared_texture_memory_egl_image_descriptor = 0x00000455,
+    shared_texture_memory_initialized_begin_state = 0x000004B0,
+    shared_texture_memory_initialized_end_state = 0x000004B1,
+    shared_texture_memory_vk_image_layout_begin_state = 0x000004B2,
+    shared_texture_memory_vk_image_layout_end_state = 0x000004B3,
+    shared_fence_vk_semaphore_opaque_fd_descriptor = 0x000004B4,
+    shared_fence_vk_semaphore_opaque_fd_export_info = 0x000004B5,
+    shared_fence_vk_semaphore_sync_fd_descriptor = 0x000004B6,
+    shared_fence_vk_semaphore_sync_fd_export_info = 0x000004B7,
+    shared_fence_vk_semaphore_zircon_handle_descriptor = 0x000004B8,
+    shared_fence_vk_semaphore_zircon_handle_export_info = 0x000004B9,
+    shared_fence_dxgi_shared_handle_descriptor = 0x000004BA,
+    shared_fence_dxgi_shared_handle_export_info = 0x000004BB,
+    shared_fence_mtl_shared_event_descriptor = 0x000004BC,
+    shared_fence_mtl_shared_event_export_info = 0x000004BD,
+};
+
+pub const FilterMode = enum(u32) {
+    nearest = 0x00000000,
+    linear = 0x00000001,
+};
+
+pub const MipmapFilterMode = enum(u32) {
+    nearest = 0x00000000,
+    linear = 0x00000001,
+};
+
+pub const FrontFace = enum(u32) {
+    ccw = 0x00000000,
+    cw = 0x00000001,
+};
+
+pub const IndexFormat = enum(u32) {
+    undefined = 0x00000000,
+    uint16 = 0x00000001,
+    uint32 = 0x00000002,
+};
+
+pub const LoadOp = enum(u32) {
+    undefined = 0x00000000,
+    clear = 0x00000001,
+    load = 0x00000002,
+};
+
+pub const LoggingType = enum(u32) {
+    verbose = 0x00000000,
+    info = 0x00000001,
+    warning = 0x00000002,
+    err = 0x00000003,
+};
+
+pub const PipelineStatisticName = enum(u32) {
+    vertex_shader_invocations = 0x00000000,
+    clipper_invocations = 0x00000001,
+    clipper_primitives_out = 0x00000002,
+    fragment_shader_invocations = 0x00000003,
+    compute_shader_invocations = 0x00000004,
+};
+
+pub const PowerPreference = enum(u32) {
+    undefined = 0x00000000,
+    low_power = 0x00000001,
+    high_performance = 0x00000002,
+};
+
+pub const PresentMode = enum(u32) {
+    immediate = 0x00000000,
+    mailbox = 0x00000001,
+    fifo = 0x00000002,
+};
+
+pub const PrimitiveTopology = enum(u32) {
+    point_list = 0x00000000,
+    line_list = 0x00000001,
+    line_strip = 0x00000002,
+    triangle_list = 0x00000003,
+    triangle_strip = 0x00000004,
+};
+
+pub const QueryType = enum(u32) {
+    occlusion = 0x00000000,
+    pipeline_statistics = 0x00000001,
+    timestamp = 0x00000002,
+};
+
+pub const RenderPassTimestampLocation = enum(u32) {
+    beginning = 0x00000000,
+    end = 0x00000001,
+};
+
+pub const RequestAdapterStatus = enum(u32) {
+    success = 0x00000000,
+    unavailable = 0x00000001,
+    err = 0x00000002,
+    unknown = 0x00000003,
+};
+
+pub const RequestDeviceStatus = enum(u32) {
+    success = 0x00000000,
+    err = 0x00000001,
+    unknown = 0x00000002,
+};
+
+pub const SType = enum(u32) {
+    invalid = 0x00000000,
+    surface_descriptor_from_metal_layer = 0x00000001,
+    surface_descriptor_from_windows_hwnd = 0x00000002,
+    surface_descriptor_from_xlib_window = 0x00000003,
+    surface_descriptor_from_canvas_html_selector = 0x00000004,
+    shader_module_spirv_descriptor = 0x00000005,
+    shader_module_wgsl_descriptor = 0x00000006,
+    primitive_depth_clip_control = 0x00000007,
+    surface_descriptor_from_wayland_surface = 0x00000008,
+    surface_descriptor_from_android_native_window = 0x00000009,
+    surface_descriptor_from_windows_core_window = 0x0000000B,
+    external_texture_binding_entry = 0x0000000C,
+    external_texture_binding_layout = 0x0000000D,
+    surface_descriptor_from_windows_swap_chain_panel = 0x0000000E,
+    render_pass_descriptor_max_draw_count = 0x0000000F,
+    dawn_texture_internal_usage_descriptor = 0x000003E8,
+    dawn_encoder_internal_usage_descriptor = 0x000003EB,
+    dawn_instance_descriptor = 0x000003EC,
+    dawn_cache_device_descriptor = 0x000003ED,
+    dawn_adapter_properties_power_preference = 0x000003EE,
+    dawn_buffer_descriptor_error_info_from_wire_client = 0x000003EF,
+    dawn_toggles_descriptor = 0x000003F0,
+    dawn_shader_module_spirv_options_descriptor = 0x000003F1,
+    request_adapter_options_luid = 0x000003F2,
+    request_adapter_options_get_gl_proc = 0x000003F3,
+    dawn_multisample_state_render_to_single_sampled = 0x000003F4,
+    dawn_render_pass_color_attachment_render_to_single_sampled = 0x000003F5,
+    shared_texture_memory_vk_image_descriptor = 0x0000044C,
+    shared_texture_memory_vk_dedicated_allocation_descriptor = 0x0000044D,
+    shared_texture_memory_a_hardware_buffer_descriptor = 0x0000044E,
+    shared_texture_memory_dma_buf_descriptor = 0x0000044F,
+    shared_texture_memory_opaque_fd_descriptor = 0x00000450,
+    shared_texture_memory_zircon_handle_descriptor = 0x00000451,
+    shared_texture_memory_dxgi_shared_handle_descriptor = 0x00000452,
+    shared_texture_memory_d3d11_texture_2d_descriptor = 0x00000453,
+    shared_texture_memory_io_surface_descriptor = 0x00000454,
+    shared_texture_memory_egl_image_descriptor = 0x00000455,
+    shared_texture_memory_initialized_begin_state = 0x000004B0,
+    shared_texture_memory_initialized_end_state = 0x000004B1,
+    shared_texture_memory_vk_image_layout_begin_state = 0x000004B2,
+    shared_texture_memory_vk_image_layout_end_state = 0x000004B3,
+    shared_fence_vk_semaphore_opaque_fd_descriptor = 0x000004B4,
+    shared_fence_vk_semaphore_opaque_fd_export_info = 0x000004B5,
+    shared_fence_vk_semaphore_syncfd_descriptor = 0x000004B6,
+    shared_fence_vk_semaphore_sync_fd_export_info = 0x000004B7,
+    shared_fence_vk_semaphore_zircon_handle_descriptor = 0x000004B8,
+    shared_fence_vk_semaphore_zircon_handle_export_info = 0x000004B9,
+    shared_fence_dxgi_shared_handle_descriptor = 0x000004BA,
+    shared_fence_dxgi_shared_handle_export_info = 0x000004BB,
+    shared_fence_mtl_shared_event_descriptor = 0x000004BC,
+    shared_fence_mtl_shared_event_export_info = 0x000004BD,
+};
+
+pub const StencilOperation = enum(u32) {
+    keep = 0x00000000,
+    zero = 0x00000001,
+    replace = 0x00000002,
+    invert = 0x00000003,
+    increment_clamp = 0x00000004,
+    decrement_clamp = 0x00000005,
+    increment_wrap = 0x00000006,
+    decrement_wrap = 0x00000007,
+};
+
+pub const StorageTextureAccess = enum(u32) {
+    undefined = 0x00000000,
+    write_only = 0x00000001,
+};
+
+pub const StoreOp = enum(u32) {
+    undefined = 0x00000000,
+    store = 0x00000001,
+    discard = 0x00000002,
+};
+
+pub const VertexFormat = enum(u32) {
+    undefined = 0x00000000,
+    uint8x2 = 0x00000001,
+    uint8x4 = 0x00000002,
+    sint8x2 = 0x00000003,
+    sint8x4 = 0x00000004,
+    unorm8x2 = 0x00000005,
+    unorm8x4 = 0x00000006,
+    snorm8x2 = 0x00000007,
+    snorm8x4 = 0x00000008,
+    uint16x2 = 0x00000009,
+    uint16x4 = 0x0000000a,
+    sint16x2 = 0x0000000b,
+    sint16x4 = 0x0000000c,
+    unorm16x2 = 0x0000000d,
+    unorm16x4 = 0x0000000e,
+    snorm16x2 = 0x0000000f,
+    snorm16x4 = 0x00000010,
+    float16x2 = 0x00000011,
+    float16x4 = 0x00000012,
+    float32 = 0x00000013,
+    float32x2 = 0x00000014,
+    float32x3 = 0x00000015,
+    float32x4 = 0x00000016,
+    uint32 = 0x00000017,
+    uint32x2 = 0x00000018,
+    uint32x3 = 0x00000019,
+    uint32x4 = 0x0000001a,
+    sint32 = 0x0000001b,
+    sint32x2 = 0x0000001c,
+    sint32x3 = 0x0000001d,
+    sint32x4 = 0x0000001e,
+};
+
+pub const VertexStepMode = enum(u32) {
+    vertex = 0x00000000,
+    instance = 0x00000001,
+    vertex_buffer_not_used = 0x00000002,
+};
+
+pub const ColorWriteMaskFlags = packed struct(u32) {
+    red: bool = false,
+    green: bool = false,
+    blue: bool = false,
+    alpha: bool = false,
+
+    _padding: u28 = 0,
+
+    comptime {
+        std.debug.assert(
+            @sizeOf(@This()) == @sizeOf(u32) and
+                @bitSizeOf(@This()) == @bitSizeOf(u32),
+        );
+    }
+
+    pub const all = ColorWriteMaskFlags{
+        .red = true,
+        .green = true,
+        .blue = true,
+        .alpha = true,
+    };
+
+    pub fn equal(a: ColorWriteMaskFlags, b: ColorWriteMaskFlags) bool {
+        return @as(u4, @truncate(@as(u32, @bitCast(a)))) == @as(u4, @truncate(@as(u32, @bitCast(b))));
+    }
+};
+
+pub const MapModeFlags = packed struct(u32) {
+    read: bool = false,
+    write: bool = false,
+
+    _padding: u30 = 0,
+
+    comptime {
+        std.debug.assert(
+            @sizeOf(@This()) == @sizeOf(u32) and
+                @bitSizeOf(@This()) == @bitSizeOf(u32),
+        );
+    }
+
+    pub const undef = MapModeFlags{};
+
+    pub fn equal(a: MapModeFlags, b: MapModeFlags) bool {
+        return @as(u2, @truncate(@as(u32, @bitCast(a)))) == @as(u2, @truncate(@as(u32, @bitCast(b))));
+    }
+};
+
+pub const ShaderStageFlags = packed struct(u32) {
+    vertex: bool = false,
+    fragment: bool = false,
+    compute: bool = false,
+
+    _padding: u29 = 0,
+
+    comptime {
+        std.debug.assert(
+            @sizeOf(@This()) == @sizeOf(u32) and
+                @bitSizeOf(@This()) == @bitSizeOf(u32),
+        );
+    }
+
+    pub const none = ShaderStageFlags{};
+
+    pub fn equal(a: ShaderStageFlags, b: ShaderStageFlags) bool {
+        return @as(u3, @truncate(@as(u32, @bitCast(a)))) == @as(u3, @truncate(@as(u32, @bitCast(b))));
+    }
+};
+
+pub const ChainedStruct = extern struct {
+    // TODO: dawn: not marked as nullable in dawn.json but in fact is.
+    next: ?*const ChainedStruct = null,
+    s_type: SType,
+};
+
+pub const ChainedStructOut = extern struct {
+    // TODO: dawn: not marked as nullable in dawn.json but in fact is.
+    next: ?*ChainedStructOut = null,
+    s_type: SType,
+};
+
+pub const BlendComponent = extern struct {
+    operation: BlendOperation = .add,
+    src_factor: BlendFactor = .one,
+    dst_factor: BlendFactor = .zero,
+};
+
+pub const Color = extern struct {
+    r: f64,
+    g: f64,
+    b: f64,
+    a: f64,
+};
+
+pub const Extent2D = extern struct {
+    width: u32,
+    height: u32,
+};
+
+pub const Extent3D = extern struct {
+    width: u32,
+    height: u32 = 1,
+    depth_or_array_layers: u32 = 1,
+};
+
+pub const Limits = extern struct {
+    max_texture_dimension_1d: u32 = limit_u32_undefined,
+    max_texture_dimension_2d: u32 = limit_u32_undefined,
+    max_texture_dimension_3d: u32 = limit_u32_undefined,
+    max_texture_array_layers: u32 = limit_u32_undefined,
+    max_bind_groups: u32 = limit_u32_undefined,
+    max_bind_groups_plus_vertex_buffers: u32 = limit_u32_undefined,
+    max_bindings_per_bind_group: u32 = limit_u32_undefined,
+    max_dynamic_uniform_buffers_per_pipeline_layout: u32 = limit_u32_undefined,
+    max_dynamic_storage_buffers_per_pipeline_layout: u32 = limit_u32_undefined,
+    max_sampled_textures_per_shader_stage: u32 = limit_u32_undefined,
+    max_samplers_per_shader_stage: u32 = limit_u32_undefined,
+    max_storage_buffers_per_shader_stage: u32 = limit_u32_undefined,
+    max_storage_textures_per_shader_stage: u32 = limit_u32_undefined,
+    max_uniform_buffers_per_shader_stage: u32 = limit_u32_undefined,
+    max_uniform_buffer_binding_size: u64 = limit_u64_undefined,
+    max_storage_buffer_binding_size: u64 = limit_u64_undefined,
+    min_uniform_buffer_offset_alignment: u32 = limit_u32_undefined,
+    min_storage_buffer_offset_alignment: u32 = limit_u32_undefined,
+    max_vertex_buffers: u32 = limit_u32_undefined,
+    max_buffer_size: u64 = limit_u64_undefined,
+    max_vertex_attributes: u32 = limit_u32_undefined,
+    max_vertex_buffer_array_stride: u32 = limit_u32_undefined,
+    max_inter_stage_shader_components: u32 = limit_u32_undefined,
+    max_inter_stage_shader_variables: u32 = limit_u32_undefined,
+    max_color_attachments: u32 = limit_u32_undefined,
+    max_color_attachment_bytes_per_sample: u32 = limit_u32_undefined,
+    max_compute_workgroup_storage_size: u32 = limit_u32_undefined,
+    max_compute_invocations_per_workgroup: u32 = limit_u32_undefined,
+    max_compute_workgroup_size_x: u32 = limit_u32_undefined,
+    max_compute_workgroup_size_y: u32 = limit_u32_undefined,
+    max_compute_workgroup_size_z: u32 = limit_u32_undefined,
+    max_compute_workgroups_per_dimension: u32 = limit_u32_undefined,
+};
+
+pub const Origin2D = extern struct {
+    x: u32 = 0,
+    y: u32 = 0,
+};
+
+pub const Origin3D = extern struct {
+    x: u32 = 0,
+    y: u32 = 0,
+    z: u32 = 0,
+};
+
+pub const CompilationMessage = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    message: ?[*:0]const u8 = null,
+    type: CompilationMessageType,
+    line_num: u64,
+    line_pos: u64,
+    offset: u64,
+    length: u64,
+    utf16_line_pos: u64,
+    utf16_offset: u64,
+    utf16_length: u64,
+};
+
+pub const ConstantEntry = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    key: [*:0]const u8,
+    value: f64,
+};
+
+pub const CopyTextureForBrowserOptions = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    flip_y: Bool32 = .false,
+    needs_color_space_conversion: Bool32 = .false,
+    src_alpha_mode: AlphaMode = .unpremultiplied,
+    src_transfer_function_parameters: ?*const [7]f32 = null,
+    conversion_matrix: ?*const [9]f32 = null,
+    dst_transfer_function_parameters: ?*const [7]f32 = null,
+    dst_alpha_mode: AlphaMode = .unpremultiplied,
+    internal_usage: Bool32 = .false,
+};
+
+pub const MultisampleState = extern struct {
+    pub const NextInChain = extern union {
+        generic: ?*const ChainedStruct,
+        dawn_multisample_state_render_to_single_sampled: *const dawn.MultisampleStateRenderToSingleSampled,
+    };
+
+    next_in_chain: NextInChain = .{ .generic = null },
+    count: u32 = 1,
+    mask: u32 = 0xFFFFFFFF,
+    alpha_to_coverage_enabled: Bool32 = .false,
+};
+
+pub const PrimitiveDepthClipControl = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .primitive_depth_clip_control },
+    unclipped_depth: Bool32 = .false,
+};
+
+pub const PrimitiveState = extern struct {
+    pub const NextInChain = extern union {
+        generic: ?*const ChainedStruct,
+        primitive_depth_clip_control: *const PrimitiveDepthClipControl,
+    };
+
+    next_in_chain: NextInChain = .{ .generic = null },
+    topology: PrimitiveTopology = .triangle_list,
+    strip_index_format: IndexFormat = .undefined,
+    front_face: FrontFace = .ccw,
+    cull_mode: CullMode = .none,
+};
+
+pub const RenderPassDescriptorMaxDrawCount = extern struct {
+    chain: ChainedStruct = .{ .next = null, .s_type = .render_pass_descriptor_max_draw_count },
+    max_draw_count: u64 = 50000000,
+};
+
+pub const StencilFaceState = extern struct {
+    compare: CompareFunction = .always,
+    fail_op: StencilOperation = .keep,
+    depth_fail_op: StencilOperation = .keep,
+    pass_op: StencilOperation = .keep,
+};
+
+pub const StorageTextureBindingLayout = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    access: StorageTextureAccess = .undefined,
+    format: Texture.Format = .undefined,
+    view_dimension: TextureView.Dimension = .dimension_undefined,
+};
+
+pub const VertexAttribute = extern struct {
+    format: VertexFormat,
+    offset: u64,
+    shader_location: u32,
+};
+
+pub const BlendState = extern struct {
+    color: BlendComponent = .{},
+    alpha: BlendComponent = .{},
+};
+
+pub const CompilationInfo = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    message_count: usize,
+    messages: ?[*]const CompilationMessage = null,
+
+    /// Helper to get messages as a slice.
+    pub fn getMessages(info: CompilationInfo) ?[]const CompilationMessage {
+        if (info.messages) |messages| {
+            return messages[0..info.message_count];
+        }
+        return null;
+    }
+};
+
+pub const DepthStencilState = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    format: Texture.Format,
+    depth_write_enabled: Bool32 = .false,
+    depth_compare: CompareFunction = .always,
+    stencil_front: StencilFaceState = .{},
+    stencil_back: StencilFaceState = .{},
+    stencil_read_mask: u32 = 0xFFFFFFFF,
+    stencil_write_mask: u32 = 0xFFFFFFFF,
+    depth_bias: i32 = 0,
+    depth_bias_slope_scale: f32 = 0.0,
+    depth_bias_clamp: f32 = 0.0,
+};
+
+pub const ImageCopyBuffer = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    layout: Texture.DataLayout,
+    buffer: *Buffer,
+};
+
+pub const ImageCopyExternalTexture = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    external_texture: *ExternalTexture,
+    origin: Origin3D,
+    natural_size: Extent2D,
+};
+
+pub const ImageCopyTexture = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    texture: *Texture,
+    mip_level: u32 = 0,
+    origin: Origin3D = .{},
+    aspect: Texture.Aspect = .all,
+};
+
+pub const ProgrammableStageDescriptor = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    module: *ShaderModule,
+    entry_point: [*:0]const u8,
+    constant_count: usize = 0,
+    constants: ?[*]const ConstantEntry = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        module: *ShaderModule,
+        entry_point: [*:0]const u8,
+        constants: ?[]const ConstantEntry = null,
+    }) ProgrammableStageDescriptor {
+        return .{
+            .next_in_chain = v.next_in_chain,
+            .module = v.module,
+            .entry_point = v.entry_point,
+            .constant_count = if (v.constants) |e| e.len else 0,
+            .constants = if (v.constants) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const RenderPassColorAttachment = extern struct {
+    pub const NextInChain = extern union {
+        generic: ?*const ChainedStruct,
+        dawn_render_pass_color_attachment_render_to_single_sampled: *const dawn.RenderPassColorAttachmentRenderToSingleSampled,
+    };
+
+    next_in_chain: NextInChain = .{ .generic = null },
+    view: ?*TextureView = null,
+    resolve_target: ?*TextureView = null,
+    load_op: LoadOp,
+    store_op: StoreOp,
+    clear_value: Color,
+};
+
+pub const RequiredLimits = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    limits: Limits,
+};
+
+/// Used to query limits from a Device or Adapter. Can be used as follows:
+///
+/// ```
+/// var supported: gpu.SupportedLimits = .{};
+/// if (!adapter.getLimits(&supported)) @panic("unsupported options");
+/// ```
+///
+/// Note that `getLimits` can only fail if `next_in_chain` options are invalid.
+pub const SupportedLimits = extern struct {
+    next_in_chain: ?*ChainedStructOut = null,
+    limits: Limits = undefined,
+};
+
+pub const VertexBufferLayout = extern struct {
+    array_stride: u64,
+    step_mode: VertexStepMode = .vertex,
+    attribute_count: usize,
+    attributes: ?[*]const VertexAttribute = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        array_stride: u64,
+        step_mode: VertexStepMode = .vertex,
+        attributes: ?[]const VertexAttribute = null,
+    }) VertexBufferLayout {
+        return .{
+            .array_stride = v.array_stride,
+            .step_mode = v.step_mode,
+            .attribute_count = if (v.attributes) |e| e.len else 0,
+            .attributes = if (v.attributes) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const ColorTargetState = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    format: Texture.Format,
+    blend: ?*const BlendState = null,
+    write_mask: ColorWriteMaskFlags = ColorWriteMaskFlags.all,
+};
+
+pub const VertexState = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    module: *ShaderModule,
+    entry_point: [*:0]const u8,
+    constant_count: usize = 0,
+    constants: ?[*]const ConstantEntry = null,
+    buffer_count: usize = 0,
+    buffers: ?[*]const VertexBufferLayout = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        module: *ShaderModule,
+        entry_point: [*:0]const u8,
+        constants: ?[]const ConstantEntry = null,
+        buffers: ?[]const VertexBufferLayout = null,
+    }) VertexState {
+        return .{
+            .next_in_chain = v.next_in_chain,
+            .module = v.module,
+            .entry_point = v.entry_point,
+            .constant_count = if (v.constants) |e| e.len else 0,
+            .constants = if (v.constants) |e| e.ptr else null,
+            .buffer_count = if (v.buffers) |e| e.len else 0,
+            .buffers = if (v.buffers) |e| e.ptr else null,
+        };
+    }
+};
+
+pub const FragmentState = extern struct {
+    next_in_chain: ?*const ChainedStruct = null,
+    module: *ShaderModule,
+    entry_point: [*:0]const u8,
+    constant_count: usize = 0,
+    constants: ?[*]const ConstantEntry = null,
+    target_count: usize,
+    targets: ?[*]const ColorTargetState = null,
+
+    /// Provides a slightly friendlier Zig API to initialize this structure.
+    pub inline fn init(v: struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        module: *ShaderModule,
+        entry_point: [*:0]const u8,
+        constants: ?[]const ConstantEntry = null,
+        targets: ?[]const ColorTargetState = null,
+    }) FragmentState {
+        return .{
+            .next_in_chain = v.next_in_chain,
+            .module = v.module,
+            .entry_point = v.entry_point,
+            .constant_count = if (v.constants) |e| e.len else 0,
+            .constants = if (v.constants) |e| e.ptr else null,
+            .target_count = if (v.targets) |e| e.len else 0,
+            .targets = if (v.targets) |e| e.ptr else null,
+        };
+    }
+};
+
+test "BackendType name" {
+    try testing.expectEqualStrings("Vulkan", BackendType.vulkan.name());
+}
+
+test "enum name" {
+    try testing.expectEqualStrings("front", @tagName(CullMode.front));
+}
+
+pub const CompilationInfoCallback = *const fn (
+    status: CompilationInfoRequestStatus,
+    compilation_info: *const CompilationInfo,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const ErrorCallback = *const fn (
+    typ: ErrorType,
+    message: [*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const LoggingCallback = *const fn (
+    typ: LoggingType,
+    message: [*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const RequestDeviceCallback = *const fn (
+    status: RequestDeviceStatus,
+    device: *Device,
+    message: ?[*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const RequestAdapterCallback = *const fn (
+    status: RequestAdapterStatus,
+    adapter: ?*Adapter,
+    message: ?[*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const CreateComputePipelineAsyncCallback = *const fn (
+    status: CreatePipelineAsyncStatus,
+    compute_pipeline: ?*ComputePipeline,
+    message: ?[*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+pub const CreateRenderPipelineAsyncCallback = *const fn (
+    status: CreatePipelineAsyncStatus,
+    pipeline: ?*RenderPipeline,
+    message: ?[*:0]const u8,
+    userdata: ?*anyopaque,
+) callconv(.C) void;
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}

--- a/src/dgpu/pipeline_layout.zig
+++ b/src/dgpu/pipeline_layout.zig
@@ -1,0 +1,38 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+const Impl = @import("interface.zig").Impl;
+
+pub const PipelineLayout = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        bind_group_layout_count: usize = 0,
+        bind_group_layouts: ?[*]const *BindGroupLayout = null,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: ?*const ChainedStruct = null,
+            label: ?[*:0]const u8 = null,
+            bind_group_layouts: ?[]const *BindGroupLayout = null,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .bind_group_layout_count = if (v.bind_group_layouts) |e| e.len else 0,
+                .bind_group_layouts = if (v.bind_group_layouts) |e| e.ptr else null,
+            };
+        }
+    };
+
+    pub inline fn setLabel(pipeline_layout: *PipelineLayout, label: [*:0]const u8) void {
+        Impl.pipelineLayoutSetLabel(pipeline_layout, label);
+    }
+
+    pub inline fn reference(pipeline_layout: *PipelineLayout) void {
+        Impl.pipelineLayoutReference(pipeline_layout);
+    }
+
+    pub inline fn release(pipeline_layout: *PipelineLayout) void {
+        Impl.pipelineLayoutRelease(pipeline_layout);
+    }
+};

--- a/src/dgpu/query_set.zig
+++ b/src/dgpu/query_set.zig
@@ -1,0 +1,57 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const PipelineStatisticName = @import("main.zig").PipelineStatisticName;
+const QueryType = @import("main.zig").QueryType;
+const Impl = @import("interface.zig").Impl;
+
+pub const QuerySet = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        type: QueryType,
+        count: u32,
+        pipeline_statistics: ?[*]const PipelineStatisticName = null,
+        pipeline_statistics_count: usize = 0,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: ?*const ChainedStruct = null,
+            label: ?[*:0]const u8 = null,
+            type: QueryType,
+            count: u32,
+            pipeline_statistics: ?[]const PipelineStatisticName = null,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .type = v.type,
+                .count = v.count,
+                .pipeline_statistics_count = if (v.pipeline_statistics) |e| e.len else 0,
+                .pipeline_statistics = if (v.pipeline_statistics) |e| e.ptr else null,
+            };
+        }
+    };
+
+    pub inline fn destroy(query_set: *QuerySet) void {
+        Impl.querySetDestroy(query_set);
+    }
+
+    pub inline fn getCount(query_set: *QuerySet) u32 {
+        return Impl.querySetGetCount(query_set);
+    }
+
+    pub inline fn getType(query_set: *QuerySet) QueryType {
+        return Impl.querySetGetType(query_set);
+    }
+
+    pub inline fn setLabel(query_set: *QuerySet, label: [*:0]const u8) void {
+        Impl.querySetSetLabel(query_set, label);
+    }
+
+    pub inline fn reference(query_set: *QuerySet) void {
+        Impl.querySetReference(query_set);
+    }
+
+    pub inline fn release(query_set: *QuerySet) void {
+        Impl.querySetRelease(query_set);
+    }
+};

--- a/src/dgpu/queue.zig
+++ b/src/dgpu/queue.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const CommandBuffer = @import("command_buffer.zig").CommandBuffer;
+const Buffer = @import("buffer.zig").Buffer;
+const Texture = @import("texture.zig").Texture;
+const ImageCopyTexture = @import("main.zig").ImageCopyTexture;
+const ImageCopyExternalTexture = @import("main.zig").ImageCopyExternalTexture;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const Extent3D = @import("main.zig").Extent3D;
+const CopyTextureForBrowserOptions = @import("main.zig").CopyTextureForBrowserOptions;
+const Impl = @import("interface.zig").Impl;
+
+pub const Queue = opaque {
+    pub const WorkDoneCallback = *const fn (
+        status: WorkDoneStatus,
+        userdata: ?*anyopaque,
+    ) callconv(.C) void;
+
+    pub const WorkDoneStatus = enum(u32) {
+        success = 0x00000000,
+        err = 0x00000001,
+        unknown = 0x00000002,
+        device_lost = 0x00000003,
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub inline fn copyExternalTextureForBrowser(queue: *Queue, source: *const ImageCopyExternalTexture, destination: *const ImageCopyTexture, copy_size: *const Extent3D, options: *const CopyTextureForBrowserOptions) void {
+        Impl.queueCopyExternalTextureForBrowser(queue, source, destination, copy_size, options);
+    }
+
+    pub inline fn copyTextureForBrowser(queue: *Queue, source: *const ImageCopyTexture, destination: *const ImageCopyTexture, copy_size: *const Extent3D, options: *const CopyTextureForBrowserOptions) void {
+        Impl.queueCopyTextureForBrowser(queue, source, destination, copy_size, options);
+    }
+
+    // TODO: dawn: does not allow unsetting this callback to null
+    pub inline fn onSubmittedWorkDone(
+        queue: *Queue,
+        signal_value: u64,
+        context: anytype,
+        comptime callback: fn (ctx: @TypeOf(context), status: WorkDoneStatus) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(status: WorkDoneStatus, userdata: ?*anyopaque) callconv(.C) void {
+                callback(if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))), status);
+            }
+        };
+        Impl.queueOnSubmittedWorkDone(queue, signal_value, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn setLabel(queue: *Queue, label: [*:0]const u8) void {
+        Impl.queueSetLabel(queue, label);
+    }
+
+    pub inline fn submit(queue: *Queue, commands: []const *const CommandBuffer) void {
+        Impl.queueSubmit(queue, commands.len, commands.ptr);
+    }
+
+    pub inline fn writeBuffer(
+        queue: *Queue,
+        buffer: *Buffer,
+        buffer_offset_bytes: u64,
+        data_slice: anytype,
+    ) void {
+        Impl.queueWriteBuffer(
+            queue,
+            buffer,
+            buffer_offset_bytes,
+            @as(*const anyopaque, @ptrCast(std.mem.sliceAsBytes(data_slice).ptr)),
+            data_slice.len * @sizeOf(std.meta.Elem(@TypeOf(data_slice))),
+        );
+    }
+
+    pub inline fn writeTexture(
+        queue: *Queue,
+        destination: *const ImageCopyTexture,
+        data_layout: *const Texture.DataLayout,
+        write_size: *const Extent3D,
+        data_slice: anytype,
+    ) void {
+        Impl.queueWriteTexture(
+            queue,
+            destination,
+            @as(*const anyopaque, @ptrCast(std.mem.sliceAsBytes(data_slice).ptr)),
+            @as(usize, @intCast(data_slice.len)) * @sizeOf(std.meta.Elem(@TypeOf(data_slice))),
+            data_layout,
+            write_size,
+        );
+    }
+
+    pub inline fn reference(queue: *Queue) void {
+        Impl.queueReference(queue);
+    }
+
+    pub inline fn release(queue: *Queue) void {
+        Impl.queueRelease(queue);
+    }
+};

--- a/src/dgpu/render_bundle.zig
+++ b/src/dgpu/render_bundle.zig
@@ -1,0 +1,21 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const Impl = @import("interface.zig").Impl;
+
+pub const RenderBundle = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub inline fn setLabel(render_bundle: *RenderBundle, label: [*:0]const u8) void {
+        Impl.renderBundleSetLabel(render_bundle, label);
+    }
+
+    pub inline fn reference(render_bundle: *RenderBundle) void {
+        Impl.renderBundleReference(render_bundle);
+    }
+
+    pub inline fn release(render_bundle: *RenderBundle) void {
+        Impl.renderBundleRelease(render_bundle);
+    }
+};

--- a/src/dgpu/render_bundle_encoder.zig
+++ b/src/dgpu/render_bundle_encoder.zig
@@ -1,0 +1,122 @@
+const Texture = @import("texture.zig").Texture;
+const Buffer = @import("buffer.zig").Buffer;
+const BindGroup = @import("bind_group.zig").BindGroup;
+const RenderPipeline = @import("render_pipeline.zig").RenderPipeline;
+const RenderBundle = @import("render_bundle.zig").RenderBundle;
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const IndexFormat = @import("main.zig").IndexFormat;
+const Impl = @import("interface.zig").Impl;
+
+pub const RenderBundleEncoder = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        color_formats_count: usize = 0,
+        color_formats: ?[*]const Texture.Format = null,
+        depth_stencil_format: Texture.Format = .undefined,
+        sample_count: u32 = 1,
+        depth_read_only: Bool32 = .false,
+        stencil_read_only: Bool32 = .false,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: ?*const ChainedStruct = null,
+            label: ?[*:0]const u8 = null,
+            color_formats: ?[]const Texture.Format = null,
+            depth_stencil_format: Texture.Format = .undefined,
+            sample_count: u32 = 1,
+            depth_read_only: bool = false,
+            stencil_read_only: bool = false,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .color_formats_count = if (v.color_formats) |e| e.len else 0,
+                .color_formats = if (v.color_formats) |e| e.ptr else null,
+                .depth_stencil_format = v.depth_stencil_format,
+                .sample_count = v.sample_count,
+                .depth_read_only = Bool32.from(v.depth_read_only),
+                .stencil_read_only = Bool32.from(v.stencil_read_only),
+            };
+        }
+    };
+
+    /// Default `instance_count`: 1
+    /// Default `first_vertex`: 0
+    /// Default `first_instance`: 0
+    pub inline fn draw(render_bundle_encoder: *RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+        Impl.renderBundleEncoderDraw(render_bundle_encoder, vertex_count, instance_count, first_vertex, first_instance);
+    }
+
+    /// Default `instance_count`: 1
+    /// Default `first_index`: 0
+    /// Default `base_vertex`: 0
+    /// Default `first_instance`: 0
+    pub inline fn drawIndexed(render_bundle_encoder: *RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+        Impl.renderBundleEncoderDrawIndexed(render_bundle_encoder, index_count, instance_count, first_index, base_vertex, first_instance);
+    }
+
+    pub inline fn drawIndexedIndirect(render_bundle_encoder: *RenderBundleEncoder, indirect_buffer: *Buffer, indirect_offset: u64) void {
+        Impl.renderBundleEncoderDrawIndexedIndirect(render_bundle_encoder, indirect_buffer, indirect_offset);
+    }
+
+    pub inline fn drawIndirect(render_bundle_encoder: *RenderBundleEncoder, indirect_buffer: *Buffer, indirect_offset: u64) void {
+        Impl.renderBundleEncoderDrawIndirect(render_bundle_encoder, indirect_buffer, indirect_offset);
+    }
+
+    pub inline fn finish(render_bundle_encoder: *RenderBundleEncoder, descriptor: ?*const RenderBundle.Descriptor) *RenderBundle {
+        return Impl.renderBundleEncoderFinish(render_bundle_encoder, descriptor);
+    }
+
+    pub inline fn insertDebugMarker(render_bundle_encoder: *RenderBundleEncoder, marker_label: [*:0]const u8) void {
+        Impl.renderBundleEncoderInsertDebugMarker(render_bundle_encoder, marker_label);
+    }
+
+    pub inline fn popDebugGroup(render_bundle_encoder: *RenderBundleEncoder) void {
+        Impl.renderBundleEncoderPopDebugGroup(render_bundle_encoder);
+    }
+
+    pub inline fn pushDebugGroup(render_bundle_encoder: *RenderBundleEncoder, group_label: [*:0]const u8) void {
+        Impl.renderBundleEncoderPushDebugGroup(render_bundle_encoder, group_label);
+    }
+
+    /// Default `dynamic_offsets`: `null`
+    pub inline fn setBindGroup(render_bundle_encoder: *RenderBundleEncoder, group_index: u32, group: *BindGroup, dynamic_offsets: ?[]const u32) void {
+        Impl.renderBundleEncoderSetBindGroup(
+            render_bundle_encoder,
+            group_index,
+            group,
+            if (dynamic_offsets) |v| v.len else 0,
+            if (dynamic_offsets) |v| v.ptr else null,
+        );
+    }
+
+    /// Default `offset`: 0
+    /// Default `size`: `gpu.whole_size`
+    pub inline fn setIndexBuffer(render_bundle_encoder: *RenderBundleEncoder, buffer: *Buffer, format: IndexFormat, offset: u64, size: u64) void {
+        Impl.renderBundleEncoderSetIndexBuffer(render_bundle_encoder, buffer, format, offset, size);
+    }
+
+    pub inline fn setLabel(render_bundle_encoder: *RenderBundleEncoder, label: [*:0]const u8) void {
+        Impl.renderBundleEncoderSetLabel(render_bundle_encoder, label);
+    }
+
+    pub inline fn setPipeline(render_bundle_encoder: *RenderBundleEncoder, pipeline: *RenderPipeline) void {
+        Impl.renderBundleEncoderSetPipeline(render_bundle_encoder, pipeline);
+    }
+
+    /// Default `offset`: 0
+    /// Default `size`: `gpu.whole_size`
+    pub inline fn setVertexBuffer(render_bundle_encoder: *RenderBundleEncoder, slot: u32, buffer: *Buffer, offset: u64, size: u64) void {
+        Impl.renderBundleEncoderSetVertexBuffer(render_bundle_encoder, slot, buffer, offset, size);
+    }
+
+    pub inline fn reference(render_bundle_encoder: *RenderBundleEncoder) void {
+        Impl.renderBundleEncoderReference(render_bundle_encoder);
+    }
+
+    pub inline fn release(render_bundle_encoder: *RenderBundleEncoder) void {
+        Impl.renderBundleEncoderRelease(render_bundle_encoder);
+    }
+};

--- a/src/dgpu/render_pass_encoder.zig
+++ b/src/dgpu/render_pass_encoder.zig
@@ -1,0 +1,128 @@
+const Buffer = @import("buffer.zig").Buffer;
+const RenderBundle = @import("render_bundle.zig").RenderBundle;
+const BindGroup = @import("bind_group.zig").BindGroup;
+const RenderPipeline = @import("render_pipeline.zig").RenderPipeline;
+const QuerySet = @import("query_set.zig").QuerySet;
+const Color = @import("main.zig").Color;
+const IndexFormat = @import("main.zig").IndexFormat;
+const Impl = @import("interface.zig").Impl;
+
+pub const RenderPassEncoder = opaque {
+    pub inline fn beginOcclusionQuery(render_pass_encoder: *RenderPassEncoder, query_index: u32) void {
+        Impl.renderPassEncoderBeginOcclusionQuery(render_pass_encoder, query_index);
+    }
+
+    /// Default `instance_count`: 1
+    /// Default `first_vertex`: 0
+    /// Default `first_instance`: 0
+    pub inline fn draw(render_pass_encoder: *RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+        Impl.renderPassEncoderDraw(render_pass_encoder, vertex_count, instance_count, first_vertex, first_instance);
+    }
+
+    /// Default `instance_count`: 1
+    /// Default `first_index`: 0
+    /// Default `base_vertex`: 0
+    /// Default `first_instance`: 0
+    pub inline fn drawIndexed(render_pass_encoder: *RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+        Impl.renderPassEncoderDrawIndexed(render_pass_encoder, index_count, instance_count, first_index, base_vertex, first_instance);
+    }
+
+    pub inline fn drawIndexedIndirect(render_pass_encoder: *RenderPassEncoder, indirect_buffer: *Buffer, indirect_offset: u64) void {
+        Impl.renderPassEncoderDrawIndexedIndirect(render_pass_encoder, indirect_buffer, indirect_offset);
+    }
+
+    pub inline fn drawIndirect(render_pass_encoder: *RenderPassEncoder, indirect_buffer: *Buffer, indirect_offset: u64) void {
+        Impl.renderPassEncoderDrawIndirect(render_pass_encoder, indirect_buffer, indirect_offset);
+    }
+
+    pub inline fn end(render_pass_encoder: *RenderPassEncoder) void {
+        Impl.renderPassEncoderEnd(render_pass_encoder);
+    }
+
+    pub inline fn endOcclusionQuery(render_pass_encoder: *RenderPassEncoder) void {
+        Impl.renderPassEncoderEndOcclusionQuery(render_pass_encoder);
+    }
+
+    pub inline fn executeBundles(
+        render_pass_encoder: *RenderPassEncoder,
+        bundles: []*const RenderBundle,
+    ) void {
+        Impl.renderPassEncoderExecuteBundles(
+            render_pass_encoder,
+            bundles.len,
+            bundles.ptr,
+        );
+    }
+
+    pub inline fn insertDebugMarker(render_pass_encoder: *RenderPassEncoder, marker_label: [*:0]const u8) void {
+        Impl.renderPassEncoderInsertDebugMarker(render_pass_encoder, marker_label);
+    }
+
+    pub inline fn popDebugGroup(render_pass_encoder: *RenderPassEncoder) void {
+        Impl.renderPassEncoderPopDebugGroup(render_pass_encoder);
+    }
+
+    pub inline fn pushDebugGroup(render_pass_encoder: *RenderPassEncoder, group_label: [*:0]const u8) void {
+        Impl.renderPassEncoderPushDebugGroup(render_pass_encoder, group_label);
+    }
+
+    /// Default `dynamic_offsets_count`: 0
+    /// Default `dynamic_offsets`: `null`
+    pub inline fn setBindGroup(render_pass_encoder: *RenderPassEncoder, group_index: u32, group: *BindGroup, dynamic_offsets: ?[]const u32) void {
+        Impl.renderPassEncoderSetBindGroup(
+            render_pass_encoder,
+            group_index,
+            group,
+            if (dynamic_offsets) |v| v.len else 0,
+            if (dynamic_offsets) |v| v.ptr else null,
+        );
+    }
+
+    pub inline fn setBlendConstant(render_pass_encoder: *RenderPassEncoder, color: *const Color) void {
+        Impl.renderPassEncoderSetBlendConstant(render_pass_encoder, color);
+    }
+
+    /// Default `offset`: 0
+    /// Default `size`: `gpu.whole_size`
+    pub inline fn setIndexBuffer(render_pass_encoder: *RenderPassEncoder, buffer: *Buffer, format: IndexFormat, offset: u64, size: u64) void {
+        Impl.renderPassEncoderSetIndexBuffer(render_pass_encoder, buffer, format, offset, size);
+    }
+
+    pub inline fn setLabel(render_pass_encoder: *RenderPassEncoder, label: [*:0]const u8) void {
+        Impl.renderPassEncoderSetLabel(render_pass_encoder, label);
+    }
+
+    pub inline fn setPipeline(render_pass_encoder: *RenderPassEncoder, pipeline: *RenderPipeline) void {
+        Impl.renderPassEncoderSetPipeline(render_pass_encoder, pipeline);
+    }
+
+    pub inline fn setScissorRect(render_pass_encoder: *RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) void {
+        Impl.renderPassEncoderSetScissorRect(render_pass_encoder, x, y, width, height);
+    }
+
+    pub inline fn setStencilReference(render_pass_encoder: *RenderPassEncoder, _reference: u32) void {
+        Impl.renderPassEncoderSetStencilReference(render_pass_encoder, _reference);
+    }
+
+    /// Default `offset`: 0
+    /// Default `size`: `gpu.whole_size`
+    pub inline fn setVertexBuffer(render_pass_encoder: *RenderPassEncoder, slot: u32, buffer: *Buffer, offset: u64, size: u64) void {
+        Impl.renderPassEncoderSetVertexBuffer(render_pass_encoder, slot, buffer, offset, size);
+    }
+
+    pub inline fn setViewport(render_pass_encoder: *RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
+        Impl.renderPassEncoderSetViewport(render_pass_encoder, x, y, width, height, min_depth, max_depth);
+    }
+
+    pub inline fn writeTimestamp(render_pass_encoder: *RenderPassEncoder, query_set: *QuerySet, query_index: u32) void {
+        Impl.renderPassEncoderWriteTimestamp(render_pass_encoder, query_set, query_index);
+    }
+
+    pub inline fn reference(render_pass_encoder: *RenderPassEncoder) void {
+        Impl.renderPassEncoderReference(render_pass_encoder);
+    }
+
+    pub inline fn release(render_pass_encoder: *RenderPassEncoder) void {
+        Impl.renderPassEncoderRelease(render_pass_encoder);
+    }
+};

--- a/src/dgpu/render_pipeline.zig
+++ b/src/dgpu/render_pipeline.zig
@@ -1,0 +1,38 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const DepthStencilState = @import("main.zig").DepthStencilState;
+const MultisampleState = @import("main.zig").MultisampleState;
+const VertexState = @import("main.zig").VertexState;
+const PrimitiveState = @import("main.zig").PrimitiveState;
+const FragmentState = @import("main.zig").FragmentState;
+const PipelineLayout = @import("pipeline_layout.zig").PipelineLayout;
+const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+const Impl = @import("interface.zig").Impl;
+
+pub const RenderPipeline = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        layout: ?*PipelineLayout = null,
+        vertex: VertexState,
+        primitive: PrimitiveState = .{},
+        depth_stencil: ?*const DepthStencilState = null,
+        multisample: MultisampleState = .{},
+        fragment: ?*const FragmentState = null,
+    };
+
+    pub inline fn getBindGroupLayout(render_pipeline: *RenderPipeline, group_index: u32) *BindGroupLayout {
+        return Impl.renderPipelineGetBindGroupLayout(render_pipeline, group_index);
+    }
+
+    pub inline fn setLabel(render_pipeline: *RenderPipeline, label: [*:0]const u8) void {
+        Impl.renderPipelineSetLabel(render_pipeline, label);
+    }
+
+    pub inline fn reference(render_pipeline: *RenderPipeline) void {
+        Impl.renderPipelineReference(render_pipeline);
+    }
+
+    pub inline fn release(render_pipeline: *RenderPipeline) void {
+        Impl.renderPipelineRelease(render_pipeline);
+    }
+};

--- a/src/dgpu/sampler.zig
+++ b/src/dgpu/sampler.zig
@@ -1,0 +1,52 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const FilterMode = @import("main.zig").FilterMode;
+const MipmapFilterMode = @import("main.zig").MipmapFilterMode;
+const CompareFunction = @import("main.zig").CompareFunction;
+const Impl = @import("interface.zig").Impl;
+
+pub const Sampler = opaque {
+    pub const AddressMode = enum(u32) {
+        repeat = 0x00000000,
+        mirror_repeat = 0x00000001,
+        clamp_to_edge = 0x00000002,
+    };
+
+    pub const BindingType = enum(u32) {
+        undefined = 0x00000000,
+        filtering = 0x00000001,
+        non_filtering = 0x00000002,
+        comparison = 0x00000003,
+    };
+
+    pub const BindingLayout = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        type: BindingType = .undefined,
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        address_mode_u: AddressMode = .clamp_to_edge,
+        address_mode_v: AddressMode = .clamp_to_edge,
+        address_mode_w: AddressMode = .clamp_to_edge,
+        mag_filter: FilterMode = .nearest,
+        min_filter: FilterMode = .nearest,
+        mipmap_filter: MipmapFilterMode = .nearest,
+        lod_min_clamp: f32 = 0.0,
+        lod_max_clamp: f32 = 32.0,
+        compare: CompareFunction = .undefined,
+        max_anisotropy: u16 = 1,
+    };
+
+    pub inline fn setLabel(sampler: *Sampler, label: [*:0]const u8) void {
+        Impl.samplerSetLabel(sampler, label);
+    }
+
+    pub inline fn reference(sampler: *Sampler) void {
+        Impl.samplerReference(sampler);
+    }
+
+    pub inline fn release(sampler: *Sampler) void {
+        Impl.samplerRelease(sampler);
+    }
+};

--- a/src/dgpu/shader_module.zig
+++ b/src/dgpu/shader_module.zig
@@ -1,0 +1,69 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const CompilationInfoCallback = @import("main.zig").CompilationInfoCallback;
+const CompilationInfoRequestStatus = @import("main.zig").CompilationInfoRequestStatus;
+const CompilationInfo = @import("main.zig").CompilationInfo;
+const Impl = @import("interface.zig").Impl;
+const dawn = @import("dawn.zig");
+
+pub const ShaderModule = opaque {
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            spirv_descriptor: ?*const SPIRVDescriptor,
+            wgsl_descriptor: ?*const WGSLDescriptor,
+            dawn_shader_module_spirv_options_descriptor: ?*const dawn.ShaderModuleSPIRVOptionsDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub const SPIRVDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shader_module_spirv_descriptor },
+        code_size: u32,
+        code: [*]const u32,
+    };
+
+    pub const WGSLDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shader_module_wgsl_descriptor },
+        code: [*:0]const u8,
+    };
+
+    pub inline fn getCompilationInfo(
+        shader_module: *ShaderModule,
+        context: anytype,
+        comptime callback: fn (
+            ctx: @TypeOf(context),
+            status: CompilationInfoRequestStatus,
+            compilation_info: *const CompilationInfo,
+        ) callconv(.Inline) void,
+    ) void {
+        const Context = @TypeOf(context);
+        const Helper = struct {
+            pub fn cCallback(
+                status: CompilationInfoRequestStatus,
+                compilation_info: *const CompilationInfo,
+                userdata: ?*anyopaque,
+            ) callconv(.C) void {
+                callback(
+                    if (Context == void) {} else @as(Context, @ptrCast(@alignCast(userdata))),
+                    status,
+                    compilation_info,
+                );
+            }
+        };
+        Impl.shaderModuleGetCompilationInfo(shader_module, Helper.cCallback, if (Context == void) null else context);
+    }
+
+    pub inline fn setLabel(shader_module: *ShaderModule, label: [*:0]const u8) void {
+        Impl.shaderModuleSetLabel(shader_module, label);
+    }
+
+    pub inline fn reference(shader_module: *ShaderModule) void {
+        Impl.shaderModuleReference(shader_module);
+    }
+
+    pub inline fn release(shader_module: *ShaderModule) void {
+        Impl.shaderModuleRelease(shader_module);
+    }
+};

--- a/src/dgpu/shared_fence.zig
+++ b/src/dgpu/shared_fence.zig
@@ -1,0 +1,91 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ChainedStructOut = @import("main.zig").ChainedStructOut;
+
+pub const SharedFence = opaque {
+    pub const Type = enum(u32) {
+        shared_fence_type_undefined = 0x00000000,
+        shared_fence_type_vk_semaphore_opaque_fd = 0x00000001,
+        shared_fence_type_vk_semaphore_sync_fd = 0x00000002,
+        shared_fence_type_vk_semaphore_zircon_handle = 0x00000003,
+        shared_fence_type_dxgi_shared_handle = 0x00000004,
+        shared_fence_type_mtl_shared_event = 0x00000005,
+    };
+
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            vk_semaphore_opaque_fd_descriptor: *const VkSemaphoreOpaqueFDDescriptor,
+            vk_semaphore_sync_fd_descriptor: *const VkSemaphoreSyncFDDescriptor,
+            vk_semaphore_zircon_handle_descriptor: *const VkSemaphoreZirconHandleDescriptor,
+            dxgi_shared_handle_descriptor: *const DXGISharedHandleDescriptor,
+            mtl_shared_event_descriptor: *const MTLSharedEventDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*]const u8,
+    };
+
+    pub const DXGISharedHandleDescriptor = extern struct {
+        chain: ChainedStruct,
+        handle: *anyopaque,
+    };
+
+    pub const DXGISharedHandleExportInfo = extern struct {
+        chain: ChainedStructOut,
+        handle: *anyopaque,
+    };
+
+    pub const ExportInfo = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStructOut,
+            dxgi_shared_handle_export_info: *const DXGISharedHandleExportInfo,
+            mtl_shared_event_export_info: *const MTLSharedEventExportInfo,
+            vk_semaphore_opaque_fd_export_info: *const VkSemaphoreOpaqueFDExportInfo,
+            vk_semaphore_sync_fd_export_info: *const VkSemaphoreSyncFDExportInfo,
+            vk_semaphore_zircon_handle_export_info: *const VkSemaphoreZirconHandleExportInfo,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        type: Type,
+    };
+
+    pub const MTLSharedEventDescriptor = extern struct {
+        chain: ChainedStruct,
+        shared_event: *anyopaque,
+    };
+
+    pub const MTLSharedEventExportInfo = extern struct {
+        chain: ChainedStructOut,
+        shared_event: *anyopaque,
+    };
+
+    pub const VkSemaphoreOpaqueFDDescriptor = extern struct {
+        chain: ChainedStruct,
+        handle: c_int,
+    };
+
+    pub const VkSemaphoreOpaqueFDExportInfo = extern struct {
+        chain: ChainedStructOut,
+        handle: c_int,
+    };
+
+    pub const VkSemaphoreSyncFDDescriptor = extern struct {
+        chain: ChainedStruct,
+        handle: c_int,
+    };
+
+    pub const VkSemaphoreSyncFDExportInfo = extern struct {
+        chain: ChainedStructOut,
+        handle: c_int,
+    };
+
+    pub const VkSemaphoreZirconHandleDescriptor = extern struct {
+        chain: ChainedStruct,
+        handle: u32,
+    };
+
+    pub const VkSemaphoreZirconHandleExportInfo = extern struct {
+        chain: ChainedStructOut,
+        handle: u32,
+    };
+};

--- a/src/dgpu/shared_texture_memory.zig
+++ b/src/dgpu/shared_texture_memory.zig
@@ -1,0 +1,124 @@
+const Texture = @import("texture.zig").Texture;
+const Bool32 = @import("main.zig").Bool32;
+const Extent3D = @import("main.zig").Extent3D;
+const SharedFence = @import("shared_fence.zig").SharedFence;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const ChainedStructOut = @import("main.zig").ChainedStructOut;
+
+pub const SharedTextureMemory = opaque {
+    pub const Properties = extern struct {
+        next_in_chain: *const ChainedStruct,
+        usage: Texture.UsageFlags,
+        size: Extent3D,
+        format: Texture.Format,
+    };
+
+    pub const VkImageDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_vk_image_descriptor },
+        vk_format: i32,
+        vk_usage_flags: Texture.UsageFlags,
+        vk_extent3D: Extent3D,
+    };
+
+    pub const AHardwareBufferDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_a_hardware_buffer_descriptor },
+        handle: *anyopaque,
+    };
+
+    pub const BeginAccessDescriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            vk_image_layout_begin_state: *const VkImageLayoutBeginState,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        initialized: Bool32,
+        fence_count: usize,
+        fences: *const SharedFence,
+        signaled_values: *const u64,
+    };
+
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            a_hardware_buffer_descriptor: *const AHardwareBufferDescriptor,
+            dma_buf_descriptor: *const DmaBufDescriptor,
+            dxgi_shared_handle_descriptor: *const DXGISharedHandleDescriptor,
+            egl_image_descriptor: *const EGLImageDescriptor,
+            io_surface_descriptor: *const IOSurfaceDescriptor,
+            opaque_fd_descriptor: *const OpaqueFDDescriptor,
+            vk_dedicated_allocation_descriptor: *const VkDedicatedAllocationDescriptor,
+            zircon_handle_descriptor: *const ZirconHandleDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*]const u8,
+    };
+
+    pub const DmaBufDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_dma_buf_descriptor },
+        memory_fd: c_int,
+        allocation_size: u64,
+        drm_modifier: u64,
+        plane_count: usize,
+        plane_offsets: *const u64,
+        plane_strides: *const u32,
+    };
+
+    pub const DXGISharedHandleDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_dxgi_shared_handle_descriptor },
+        handle: *anyopaque,
+    };
+
+    pub const EGLImageDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_egl_image_descriptor },
+        image: *anyopaque,
+    };
+
+    pub const EndAccessState = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            vk_image_layout_end_state: *const VkImageLayoutEndState,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        initialized: Bool32,
+        fence_count: usize,
+        fences: *const SharedFence,
+        signaled_values: *const u64,
+    };
+
+    pub const IOSurfaceDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_io_surface_descriptor },
+        ioSurface: *anyopaque,
+    };
+
+    pub const OpaqueFDDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_opaque_fd_descriptor },
+        memory_fd: c_int,
+        allocation_size: u64,
+    };
+
+    pub const VkDedicatedAllocationDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_vk_dedicated_allocation_descriptor },
+        dedicated_allocation: Bool32,
+    };
+
+    pub const VkImageLayoutBeginState = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_vk_image_layout_begin_state },
+        old_layout: i32,
+        new_layout: i32,
+    };
+
+    pub const VkImageLayoutEndState = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_vk_image_layout_end_state },
+        old_layout: i32,
+        new_layout: i32,
+    };
+
+    pub const ZirconHandleDescriptor = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .shared_texture_memory_zircon_handle_descriptor },
+        memory_fd: u32,
+        allocation_size: u64,
+    };
+};

--- a/src/dgpu/surface.zig
+++ b/src/dgpu/surface.zig
@@ -1,0 +1,72 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const Impl = @import("interface.zig").Impl;
+
+pub const Surface = opaque {
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            from_android_native_window: *const DescriptorFromAndroidNativeWindow,
+            from_canvas_html_selector: *const DescriptorFromCanvasHTMLSelector,
+            from_metal_layer: *const DescriptorFromMetalLayer,
+            from_wayland_surface: *const DescriptorFromWaylandSurface,
+            from_windows_core_window: *const DescriptorFromWindowsCoreWindow,
+            from_windows_hwnd: *const DescriptorFromWindowsHWND,
+            from_windows_swap_chain_panel: *const DescriptorFromWindowsSwapChainPanel,
+            from_xlib_window: *const DescriptorFromXlibWindow,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+    };
+
+    pub const DescriptorFromAndroidNativeWindow = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_android_native_window },
+        window: *anyopaque,
+    };
+
+    pub const DescriptorFromCanvasHTMLSelector = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_canvas_html_selector },
+        selector: [*:0]const u8,
+    };
+
+    pub const DescriptorFromMetalLayer = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_metal_layer },
+        layer: *anyopaque,
+    };
+
+    pub const DescriptorFromWaylandSurface = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_wayland_surface },
+        display: *anyopaque,
+        surface: *anyopaque,
+    };
+
+    pub const DescriptorFromWindowsCoreWindow = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_windows_core_window },
+        core_window: *anyopaque,
+    };
+
+    pub const DescriptorFromWindowsHWND = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_windows_hwnd },
+        hinstance: *anyopaque,
+        hwnd: *anyopaque,
+    };
+
+    pub const DescriptorFromWindowsSwapChainPanel = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_windows_swap_chain_panel },
+        swap_chain_panel: *anyopaque,
+    };
+
+    pub const DescriptorFromXlibWindow = extern struct {
+        chain: ChainedStruct = .{ .next = null, .s_type = .surface_descriptor_from_xlib_window },
+        display: *anyopaque,
+        window: u32,
+    };
+
+    pub inline fn reference(surface: *Surface) void {
+        Impl.surfaceReference(surface);
+    }
+
+    pub inline fn release(surface: *Surface) void {
+        Impl.surfaceRelease(surface);
+    }
+};

--- a/src/dgpu/swap_chain.zig
+++ b/src/dgpu/swap_chain.zig
@@ -1,0 +1,37 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const PresentMode = @import("main.zig").PresentMode;
+const Texture = @import("texture.zig").Texture;
+const TextureView = @import("texture_view.zig").TextureView;
+const Impl = @import("interface.zig").Impl;
+
+pub const SwapChain = opaque {
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        usage: Texture.UsageFlags,
+        format: Texture.Format,
+        width: u32,
+        height: u32,
+        present_mode: PresentMode,
+    };
+
+    pub inline fn getCurrentTexture(swap_chain: *SwapChain) ?*Texture {
+        return Impl.swapChainGetCurrentTexture(swap_chain);
+    }
+
+    pub inline fn getCurrentTextureView(swap_chain: *SwapChain) ?*TextureView {
+        return Impl.swapChainGetCurrentTextureView(swap_chain);
+    }
+
+    pub inline fn present(swap_chain: *SwapChain) void {
+        Impl.swapChainPresent(swap_chain);
+    }
+
+    pub inline fn reference(swap_chain: *SwapChain) void {
+        Impl.swapChainReference(swap_chain);
+    }
+
+    pub inline fn release(swap_chain: *SwapChain) void {
+        Impl.swapChainRelease(swap_chain);
+    }
+};

--- a/src/dgpu/texture.zig
+++ b/src/dgpu/texture.zig
@@ -1,0 +1,266 @@
+const std = @import("std");
+const Bool32 = @import("main.zig").Bool32;
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const TextureView = @import("texture_view.zig").TextureView;
+const Extent3D = @import("main.zig").Extent3D;
+const Impl = @import("interface.zig").Impl;
+const types = @import("main.zig");
+const dawn = @import("dawn.zig");
+
+pub const Texture = opaque {
+    pub const Aspect = enum(u32) {
+        all = 0x00000000,
+        stencil_only = 0x00000001,
+        depth_only = 0x00000002,
+        plane0_only = 0x00000003,
+        plane1_only = 0x00000004,
+    };
+
+    pub const Dimension = enum(u32) {
+        dimension_1d = 0x00000000,
+        dimension_2d = 0x00000001,
+        dimension_3d = 0x00000002,
+    };
+
+    pub const Format = enum(u32) {
+        undefined = 0x00000000,
+        r8_unorm = 0x00000001,
+        r8_snorm = 0x00000002,
+        r8_uint = 0x00000003,
+        r8_sint = 0x00000004,
+        r16_uint = 0x00000005,
+        r16_sint = 0x00000006,
+        r16_float = 0x00000007,
+        rg8_unorm = 0x00000008,
+        rg8_snorm = 0x00000009,
+        rg8_uint = 0x0000000a,
+        rg8_sint = 0x0000000b,
+        r32_float = 0x0000000c,
+        r32_uint = 0x0000000d,
+        r32_sint = 0x0000000e,
+        rg16_uint = 0x0000000f,
+        rg16_sint = 0x00000010,
+        rg16_float = 0x00000011,
+        rgba8_unorm = 0x00000012,
+        rgba8_unorm_srgb = 0x00000013,
+        rgba8_snorm = 0x00000014,
+        rgba8_uint = 0x00000015,
+        rgba8_sint = 0x00000016,
+        bgra8_unorm = 0x00000017,
+        bgra8_unorm_srgb = 0x00000018,
+        rgb10_a2_unorm = 0x00000019,
+        rg11_b10_ufloat = 0x0000001a,
+        rgb9_e5_ufloat = 0x0000001b,
+        rg32_float = 0x0000001c,
+        rg32_uint = 0x0000001d,
+        rg32_sint = 0x0000001e,
+        rgba16_uint = 0x0000001f,
+        rgba16_sint = 0x00000020,
+        rgba16_float = 0x00000021,
+        rgba32_float = 0x00000022,
+        rgba32_uint = 0x00000023,
+        rgba32_sint = 0x00000024,
+        stencil8 = 0x00000025,
+        depth16_unorm = 0x00000026,
+        depth24_plus = 0x00000027,
+        depth24_plus_stencil8 = 0x00000028,
+        depth32_float = 0x00000029,
+        depth32_float_stencil8 = 0x0000002a,
+        bc1_rgba_unorm = 0x0000002b,
+        bc1_rgba_unorm_srgb = 0x0000002c,
+        bc2_rgba_unorm = 0x0000002d,
+        bc2_rgba_unorm_srgb = 0x0000002e,
+        bc3_rgba_unorm = 0x0000002f,
+        bc3_rgba_unorm_srgb = 0x00000030,
+        bc4_runorm = 0x00000031,
+        bc4_rsnorm = 0x00000032,
+        bc5_rg_unorm = 0x00000033,
+        bc5_rg_snorm = 0x00000034,
+        bc6_hrgb_ufloat = 0x00000035,
+        bc6_hrgb_float = 0x00000036,
+        bc7_rgba_unorm = 0x00000037,
+        bc7_rgba_unorm_srgb = 0x00000038,
+        etc2_rgb8_unorm = 0x00000039,
+        etc2_rgb8_unorm_srgb = 0x0000003a,
+        etc2_rgb8_a1_unorm = 0x0000003b,
+        etc2_rgb8_a1_unorm_srgb = 0x0000003c,
+        etc2_rgba8_unorm = 0x0000003d,
+        etc2_rgba8_unorm_srgb = 0x0000003e,
+        eacr11_unorm = 0x0000003f,
+        eacr11_snorm = 0x00000040,
+        eacrg11_unorm = 0x00000041,
+        eacrg11_snorm = 0x00000042,
+        astc4x4_unorm = 0x00000043,
+        astc4x4_unorm_srgb = 0x00000044,
+        astc5x4_unorm = 0x00000045,
+        astc5x4_unorm_srgb = 0x00000046,
+        astc5x5_unorm = 0x00000047,
+        astc5x5_unorm_srgb = 0x00000048,
+        astc6x5_unorm = 0x00000049,
+        astc6x5_unorm_srgb = 0x0000004a,
+        astc6x6_unorm = 0x0000004b,
+        astc6x6_unorm_srgb = 0x0000004c,
+        astc8x5_unorm = 0x0000004d,
+        astc8x5_unorm_srgb = 0x0000004e,
+        astc8x6_unorm = 0x0000004f,
+        astc8x6_unorm_srgb = 0x00000050,
+        astc8x8_unorm = 0x00000051,
+        astc8x8_unorm_srgb = 0x00000052,
+        astc10x5_unorm = 0x00000053,
+        astc10x5_unorm_srgb = 0x00000054,
+        astc10x6_unorm = 0x00000055,
+        astc10x6_unorm_srgb = 0x00000056,
+        astc10x8_unorm = 0x00000057,
+        astc10x8_unorm_srgb = 0x00000058,
+        astc10x10_unorm = 0x00000059,
+        astc10x10_unorm_srgb = 0x0000005a,
+        astc12x10_unorm = 0x0000005b,
+        astc12x10_unorm_srgb = 0x0000005c,
+        astc12x12_unorm = 0x0000005d,
+        astc12x12_unorm_srgb = 0x0000005e,
+        r8_bg8_biplanar420_unorm = 0x0000005f,
+    };
+
+    pub const SampleType = enum(u32) {
+        undefined = 0x00000000,
+        float = 0x00000001,
+        unfilterable_float = 0x00000002,
+        depth = 0x00000003,
+        sint = 0x00000004,
+        uint = 0x00000005,
+    };
+
+    pub const UsageFlags = packed struct(u32) {
+        copy_src: bool = false,
+        copy_dst: bool = false,
+        texture_binding: bool = false,
+        storage_binding: bool = false,
+        render_attachment: bool = false,
+        transient_attachment: bool = false,
+
+        _padding: u26 = 0,
+
+        comptime {
+            std.debug.assert(
+                @sizeOf(@This()) == @sizeOf(u32) and
+                    @bitSizeOf(@This()) == @bitSizeOf(u32),
+            );
+        }
+
+        pub const none = UsageFlags{};
+
+        pub fn equal(a: UsageFlags, b: UsageFlags) bool {
+            return @as(u6, @truncate(@as(u32, @bitCast(a)))) == @as(u6, @truncate(@as(u32, @bitCast(b))));
+        }
+    };
+
+    pub const BindingLayout = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        sample_type: SampleType = .undefined,
+        view_dimension: TextureView.Dimension = .dimension_undefined,
+        multisampled: Bool32 = .false,
+    };
+
+    pub const DataLayout = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        offset: u64 = 0,
+        bytes_per_row: u32 = types.copy_stride_undefined,
+        rows_per_image: u32 = types.copy_stride_undefined,
+    };
+
+    pub const Descriptor = extern struct {
+        pub const NextInChain = extern union {
+            generic: ?*const ChainedStruct,
+            dawn_texture_internal_usage_descriptor: *const dawn.TextureInternalUsageDescriptor,
+        };
+
+        next_in_chain: NextInChain = .{ .generic = null },
+        label: ?[*:0]const u8 = null,
+        usage: UsageFlags,
+        dimension: Dimension = .dimension_2d,
+        size: Extent3D,
+        format: Format,
+        mip_level_count: u32 = 1,
+        sample_count: u32 = 1,
+        view_format_count: usize = 0,
+        view_formats: ?[*]const Format = null,
+
+        /// Provides a slightly friendlier Zig API to initialize this structure.
+        pub inline fn init(v: struct {
+            next_in_chain: NextInChain = .{ .generic = null },
+            label: ?[*:0]const u8 = null,
+            usage: UsageFlags,
+            dimension: Dimension = .dimension_2d,
+            size: Extent3D,
+            format: Format,
+            mip_level_count: u32 = 1,
+            sample_count: u32 = 1,
+            view_formats: ?[]const Format = null,
+        }) Descriptor {
+            return .{
+                .next_in_chain = v.next_in_chain,
+                .label = v.label,
+                .usage = v.usage,
+                .dimension = v.dimension,
+                .size = v.size,
+                .format = v.format,
+                .mip_level_count = v.mip_level_count,
+                .sample_count = v.sample_count,
+                .view_format_count = if (v.view_formats) |e| e.len else 0,
+                .view_formats = if (v.view_formats) |e| e.ptr else null,
+            };
+        }
+    };
+
+    pub inline fn createView(texture: *Texture, descriptor: ?*const TextureView.Descriptor) *TextureView {
+        return Impl.textureCreateView(texture, descriptor);
+    }
+
+    pub inline fn destroy(texture: *Texture) void {
+        Impl.textureDestroy(texture);
+    }
+
+    pub inline fn getDepthOrArrayLayers(texture: *Texture) u32 {
+        return Impl.textureGetDepthOrArrayLayers(texture);
+    }
+
+    pub inline fn getDimension(texture: *Texture) Dimension {
+        return Impl.textureGetDimension(texture);
+    }
+
+    pub inline fn getFormat(texture: *Texture) Format {
+        return Impl.textureGetFormat(texture);
+    }
+
+    pub inline fn getHeight(texture: *Texture) u32 {
+        return Impl.textureGetHeight(texture);
+    }
+
+    pub inline fn getMipLevelCount(texture: *Texture) u32 {
+        return Impl.textureGetMipLevelCount(texture);
+    }
+
+    pub inline fn getSampleCount(texture: *Texture) u32 {
+        return Impl.textureGetSampleCount(texture);
+    }
+
+    pub inline fn getUsage(texture: *Texture) UsageFlags {
+        return Impl.textureGetUsage(texture);
+    }
+
+    pub inline fn getWidth(texture: *Texture) u32 {
+        return Impl.textureGetWidth(texture);
+    }
+
+    pub inline fn setLabel(texture: *Texture, label: [*:0]const u8) void {
+        Impl.textureSetLabel(texture, label);
+    }
+
+    pub inline fn reference(texture: *Texture) void {
+        Impl.textureReference(texture);
+    }
+
+    pub inline fn release(texture: *Texture) void {
+        Impl.textureRelease(texture);
+    }
+};

--- a/src/dgpu/texture_view.zig
+++ b/src/dgpu/texture_view.zig
@@ -1,0 +1,40 @@
+const ChainedStruct = @import("main.zig").ChainedStruct;
+const Texture = @import("texture.zig").Texture;
+const Impl = @import("interface.zig").Impl;
+const types = @import("main.zig");
+
+pub const TextureView = opaque {
+    pub const Dimension = enum(u32) {
+        dimension_undefined = 0x00000000,
+        dimension_1d = 0x00000001,
+        dimension_2d = 0x00000002,
+        dimension_2d_array = 0x00000003,
+        dimension_cube = 0x00000004,
+        dimension_cube_array = 0x00000005,
+        dimension_3d = 0x00000006,
+    };
+
+    pub const Descriptor = extern struct {
+        next_in_chain: ?*const ChainedStruct = null,
+        label: ?[*:0]const u8 = null,
+        format: Texture.Format = .undefined,
+        dimension: Dimension = .dimension_undefined,
+        base_mip_level: u32 = 0,
+        mip_level_count: u32 = types.mip_level_count_undefined,
+        base_array_layer: u32 = 0,
+        array_layer_count: u32 = types.array_layer_count_undefined,
+        aspect: Texture.Aspect = .all,
+    };
+
+    pub inline fn setLabel(texture_view: *TextureView, label: [*:0]const u8) void {
+        Impl.textureViewSetLabel(texture_view, label);
+    }
+
+    pub inline fn reference(texture_view: *TextureView) void {
+        Impl.textureViewReference(texture_view);
+    }
+
+    pub inline fn release(texture_view: *TextureView) void {
+        Impl.textureViewRelease(texture_view);
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const gpu = @import("gpu");
 pub const dgpu = @import("dgpu/main.zig");
 const shader = @import("shader.zig");
 const utils = @import("utils.zig");
 
-const backend_type: gpu.BackendType = switch (builtin.target.os.tag) {
+const backend_type: dgpu.BackendType = switch (builtin.target.os.tag) {
     .linux => .vulkan,
     .macos, .ios => .metal,
     .windows => .d3d12,
@@ -28,65 +27,65 @@ pub const Impl = struct {
         try impl.init(alloc, options);
     }
 
-    pub inline fn createInstance(descriptor: ?*const gpu.Instance.Descriptor) ?*gpu.Instance {
+    pub inline fn createInstance(descriptor: ?*const dgpu.Instance.Descriptor) ?*dgpu.Instance {
         if (builtin.mode == .Debug and !inited) {
-            std.log.err("dusk not initialized; did you forget to call gpu.Impl.init()?", .{});
+            std.log.err("dusk not initialized; did you forget to call dgpu.Impl.init()?", .{});
         }
 
-        const instance = impl.Instance.init(descriptor orelse &gpu.Instance.Descriptor{}) catch unreachable;
-        return @as(*gpu.Instance, @ptrCast(instance));
+        const instance = impl.Instance.init(descriptor orelse &dgpu.Instance.Descriptor{}) catch unreachable;
+        return @as(*dgpu.Instance, @ptrCast(instance));
     }
 
-    pub inline fn getProcAddress(device: *gpu.Device, proc_name: [*:0]const u8) ?gpu.Proc {
+    pub inline fn getProcAddress(device: *dgpu.Device, proc_name: [*:0]const u8) ?dgpu.Proc {
         _ = device;
         _ = proc_name;
         unreachable;
     }
 
-    pub inline fn adapterCreateDevice(adapter_raw: *gpu.Adapter, descriptor: ?*const gpu.Device.Descriptor) ?*gpu.Device {
+    pub inline fn adapterCreateDevice(adapter_raw: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor) ?*dgpu.Device {
         const adapter: *impl.Adapter = @ptrCast(@alignCast(adapter_raw));
         const device = adapter.createDevice(descriptor) catch return null;
         if (descriptor) |desc| {
             device.lost_cb = desc.device_lost_callback;
             device.lost_cb_userdata = desc.device_lost_userdata;
         }
-        return @as(*gpu.Device, @ptrCast(device));
+        return @as(*dgpu.Device, @ptrCast(device));
     }
 
-    pub inline fn adapterEnumerateFeatures(adapter: *gpu.Adapter, features: ?[*]gpu.FeatureName) usize {
+    pub inline fn adapterEnumerateFeatures(adapter: *dgpu.Adapter, features: ?[*]dgpu.FeatureName) usize {
         _ = adapter;
         _ = features;
         unreachable;
     }
 
-    pub inline fn adapterGetLimits(adapter: *gpu.Adapter, limits: *gpu.SupportedLimits) u32 {
+    pub inline fn adapterGetLimits(adapter: *dgpu.Adapter, limits: *dgpu.SupportedLimits) u32 {
         _ = adapter;
         _ = limits;
         unreachable;
     }
 
-    pub inline fn adapterGetInstance(adapter: *gpu.Adapter) *gpu.Instance {
+    pub inline fn adapterGetInstance(adapter: *dgpu.Adapter) *dgpu.Instance {
         _ = adapter;
         unreachable;
     }
 
-    pub inline fn adapterGetProperties(adapter_raw: *gpu.Adapter, properties: *gpu.Adapter.Properties) void {
+    pub inline fn adapterGetProperties(adapter_raw: *dgpu.Adapter, properties: *dgpu.Adapter.Properties) void {
         const adapter: *impl.Adapter = @ptrCast(@alignCast(adapter_raw));
         properties.* = adapter.getProperties();
     }
 
-    pub inline fn adapterHasFeature(adapter: *gpu.Adapter, feature: gpu.FeatureName) u32 {
+    pub inline fn adapterHasFeature(adapter: *dgpu.Adapter, feature: dgpu.FeatureName) u32 {
         _ = adapter;
         _ = feature;
         unreachable;
     }
 
-    pub inline fn adapterPropertiesFreeMembers(value: gpu.Adapter.Properties) void {
+    pub inline fn adapterPropertiesFreeMembers(value: dgpu.Adapter.Properties) void {
         _ = value;
         unreachable;
     }
 
-    pub inline fn adapterRequestDevice(adapter: *gpu.Adapter, descriptor: ?*const gpu.Device.Descriptor, callback: gpu.RequestDeviceCallback, userdata: ?*anyopaque) void {
+    pub inline fn adapterRequestDevice(adapter: *dgpu.Adapter, descriptor: ?*const dgpu.Device.Descriptor, callback: dgpu.RequestDeviceCallback, userdata: ?*anyopaque) void {
         _ = adapter;
         _ = descriptor;
         _ = callback;
@@ -94,128 +93,128 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn adapterReference(adapter_raw: *gpu.Adapter) void {
+    pub inline fn adapterReference(adapter_raw: *dgpu.Adapter) void {
         const adapter: *impl.Adapter = @ptrCast(@alignCast(adapter_raw));
         adapter.manager.reference();
     }
 
-    pub inline fn adapterRelease(adapter_raw: *gpu.Adapter) void {
+    pub inline fn adapterRelease(adapter_raw: *dgpu.Adapter) void {
         const adapter: *impl.Adapter = @ptrCast(@alignCast(adapter_raw));
         adapter.manager.release();
     }
 
-    pub inline fn bindGroupSetLabel(bind_group: *gpu.BindGroup, label: [*:0]const u8) void {
+    pub inline fn bindGroupSetLabel(bind_group: *dgpu.BindGroup, label: [*:0]const u8) void {
         _ = bind_group;
         _ = label;
         unreachable;
     }
 
-    pub inline fn bindGroupReference(bind_group_raw: *gpu.BindGroup) void {
+    pub inline fn bindGroupReference(bind_group_raw: *dgpu.BindGroup) void {
         const bind_group: *impl.BindGroup = @ptrCast(@alignCast(bind_group_raw));
         bind_group.manager.reference();
     }
 
-    pub inline fn bindGroupRelease(bind_group_raw: *gpu.BindGroup) void {
+    pub inline fn bindGroupRelease(bind_group_raw: *dgpu.BindGroup) void {
         const bind_group: *impl.BindGroup = @ptrCast(@alignCast(bind_group_raw));
         bind_group.manager.release();
     }
 
-    pub inline fn bindGroupLayoutSetLabel(bind_group_layout: *gpu.BindGroupLayout, label: [*:0]const u8) void {
+    pub inline fn bindGroupLayoutSetLabel(bind_group_layout: *dgpu.BindGroupLayout, label: [*:0]const u8) void {
         _ = bind_group_layout;
         _ = label;
         unreachable;
     }
 
-    pub inline fn bindGroupLayoutReference(bind_group_layout_raw: *gpu.BindGroupLayout) void {
+    pub inline fn bindGroupLayoutReference(bind_group_layout_raw: *dgpu.BindGroupLayout) void {
         const bind_group_layout: *impl.BindGroupLayout = @ptrCast(@alignCast(bind_group_layout_raw));
         bind_group_layout.manager.reference();
     }
 
-    pub inline fn bindGroupLayoutRelease(bind_group_layout_raw: *gpu.BindGroupLayout) void {
+    pub inline fn bindGroupLayoutRelease(bind_group_layout_raw: *dgpu.BindGroupLayout) void {
         const bind_group_layout: *impl.BindGroupLayout = @ptrCast(@alignCast(bind_group_layout_raw));
         bind_group_layout.manager.release();
     }
 
-    pub inline fn bufferDestroy(buffer: *gpu.Buffer) void {
+    pub inline fn bufferDestroy(buffer: *dgpu.Buffer) void {
         _ = buffer;
         unreachable;
     }
 
-    pub inline fn bufferGetConstMappedRange(buffer_raw: *gpu.Buffer, offset: usize, size: usize) ?*const anyopaque {
+    pub inline fn bufferGetConstMappedRange(buffer_raw: *dgpu.Buffer, offset: usize, size: usize) ?*const anyopaque {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         return buffer.getConstMappedRange(offset, size) catch unreachable;
     }
 
-    pub inline fn bufferGetMappedRange(buffer_raw: *gpu.Buffer, offset: usize, size: usize) ?*anyopaque {
+    pub inline fn bufferGetMappedRange(buffer_raw: *dgpu.Buffer, offset: usize, size: usize) ?*anyopaque {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         return buffer.getConstMappedRange(offset, size) catch unreachable;
     }
 
-    pub inline fn bufferGetSize(buffer: *gpu.Buffer) u64 {
+    pub inline fn bufferGetSize(buffer: *dgpu.Buffer) u64 {
         _ = buffer;
         unreachable;
     }
 
-    pub inline fn bufferGetUsage(buffer: *gpu.Buffer) gpu.Buffer.UsageFlags {
+    pub inline fn bufferGetUsage(buffer: *dgpu.Buffer) dgpu.Buffer.UsageFlags {
         _ = buffer;
         unreachable;
     }
 
-    pub inline fn bufferMapAsync(buffer_raw: *gpu.Buffer, mode: gpu.MapModeFlags, offset: usize, size: usize, callback: gpu.Buffer.MapCallback, userdata: ?*anyopaque) void {
+    pub inline fn bufferMapAsync(buffer_raw: *dgpu.Buffer, mode: dgpu.MapModeFlags, offset: usize, size: usize, callback: dgpu.Buffer.MapCallback, userdata: ?*anyopaque) void {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         buffer.mapAsync(mode, offset, size, callback, userdata) catch unreachable;
     }
 
-    pub inline fn bufferSetLabel(buffer: *gpu.Buffer, label: [*:0]const u8) void {
+    pub inline fn bufferSetLabel(buffer: *dgpu.Buffer, label: [*:0]const u8) void {
         _ = buffer;
         _ = label;
         unreachable;
     }
 
-    pub inline fn bufferUnmap(buffer_raw: *gpu.Buffer) void {
+    pub inline fn bufferUnmap(buffer_raw: *dgpu.Buffer) void {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         buffer.unmap() catch unreachable;
     }
 
-    pub inline fn bufferReference(buffer_raw: *gpu.Buffer) void {
+    pub inline fn bufferReference(buffer_raw: *dgpu.Buffer) void {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         buffer.manager.reference();
     }
 
-    pub inline fn bufferRelease(buffer_raw: *gpu.Buffer) void {
+    pub inline fn bufferRelease(buffer_raw: *dgpu.Buffer) void {
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         buffer.manager.release();
     }
 
-    pub inline fn commandBufferSetLabel(command_buffer: *gpu.CommandBuffer, label: [*:0]const u8) void {
+    pub inline fn commandBufferSetLabel(command_buffer: *dgpu.CommandBuffer, label: [*:0]const u8) void {
         _ = command_buffer;
         _ = label;
         unreachable;
     }
 
-    pub inline fn commandBufferReference(command_buffer_raw: *gpu.CommandBuffer) void {
+    pub inline fn commandBufferReference(command_buffer_raw: *dgpu.CommandBuffer) void {
         const command_buffer: *impl.CommandBuffer = @ptrCast(@alignCast(command_buffer_raw));
         command_buffer.manager.reference();
     }
 
-    pub inline fn commandBufferRelease(command_buffer_raw: *gpu.CommandBuffer) void {
+    pub inline fn commandBufferRelease(command_buffer_raw: *dgpu.CommandBuffer) void {
         const command_buffer: *impl.CommandBuffer = @ptrCast(@alignCast(command_buffer_raw));
         command_buffer.manager.release();
     }
 
-    pub inline fn commandEncoderBeginComputePass(command_encoder_raw: *gpu.CommandEncoder, descriptor: ?*const gpu.ComputePassDescriptor) *gpu.ComputePassEncoder {
+    pub inline fn commandEncoderBeginComputePass(command_encoder_raw: *dgpu.CommandEncoder, descriptor: ?*const dgpu.ComputePassDescriptor) *dgpu.ComputePassEncoder {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         const compute_pass = command_encoder.beginComputePass(descriptor orelse &.{}) catch unreachable;
         return @ptrCast(compute_pass);
     }
 
-    pub inline fn commandEncoderBeginRenderPass(command_encoder_raw: *gpu.CommandEncoder, descriptor: *const gpu.RenderPassDescriptor) *gpu.RenderPassEncoder {
+    pub inline fn commandEncoderBeginRenderPass(command_encoder_raw: *dgpu.CommandEncoder, descriptor: *const dgpu.RenderPassDescriptor) *dgpu.RenderPassEncoder {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         const render_pass = command_encoder.beginRenderPass(descriptor) catch unreachable;
         return @ptrCast(render_pass);
     }
 
-    pub inline fn commandEncoderClearBuffer(command_encoder: *gpu.CommandEncoder, buffer: *gpu.Buffer, offset: u64, size: u64) void {
+    pub inline fn commandEncoderClearBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
         _ = command_encoder;
         _ = buffer;
         _ = offset;
@@ -223,7 +222,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderCopyBufferToBuffer(command_encoder_raw: *gpu.CommandEncoder, source_raw: *gpu.Buffer, source_offset: u64, destination_raw: *gpu.Buffer, destination_offset: u64, size: u64) void {
+    pub inline fn commandEncoderCopyBufferToBuffer(command_encoder_raw: *dgpu.CommandEncoder, source_raw: *dgpu.Buffer, source_offset: u64, destination_raw: *dgpu.Buffer, destination_offset: u64, size: u64) void {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         const source: *impl.Buffer = @ptrCast(@alignCast(source_raw));
         const destination: *impl.Buffer = @ptrCast(@alignCast(destination_raw));
@@ -231,7 +230,7 @@ pub const Impl = struct {
         command_encoder.copyBufferToBuffer(source, source_offset, destination, destination_offset, size) catch unreachable;
     }
 
-    pub inline fn commandEncoderCopyBufferToTexture(command_encoder: *gpu.CommandEncoder, source: *const gpu.ImageCopyBuffer, destination: *const gpu.ImageCopyTexture, copy_size: *const gpu.Extent3D) void {
+    pub inline fn commandEncoderCopyBufferToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyBuffer, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
         _ = command_encoder;
         _ = source;
         _ = destination;
@@ -239,7 +238,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderCopyTextureToBuffer(command_encoder: *gpu.CommandEncoder, source: *const gpu.ImageCopyTexture, destination: *const gpu.ImageCopyBuffer, copy_size: *const gpu.Extent3D) void {
+    pub inline fn commandEncoderCopyTextureToBuffer(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyBuffer, copy_size: *const dgpu.Extent3D) void {
         _ = command_encoder;
         _ = source;
         _ = destination;
@@ -247,7 +246,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderCopyTextureToTexture(command_encoder: *gpu.CommandEncoder, source: *const gpu.ImageCopyTexture, destination: *const gpu.ImageCopyTexture, copy_size: *const gpu.Extent3D) void {
+    pub inline fn commandEncoderCopyTextureToTexture(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
         _ = command_encoder;
         _ = source;
         _ = destination;
@@ -255,7 +254,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderCopyTextureToTextureInternal(command_encoder: *gpu.CommandEncoder, source: *const gpu.ImageCopyTexture, destination: *const gpu.ImageCopyTexture, copy_size: *const gpu.Extent3D) void {
+    pub inline fn commandEncoderCopyTextureToTextureInternal(command_encoder: *dgpu.CommandEncoder, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D) void {
         _ = command_encoder;
         _ = source;
         _ = destination;
@@ -263,37 +262,37 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderFinish(command_encoder_raw: *gpu.CommandEncoder, descriptor: ?*const gpu.CommandBuffer.Descriptor) *gpu.CommandBuffer {
+    pub inline fn commandEncoderFinish(command_encoder_raw: *dgpu.CommandEncoder, descriptor: ?*const dgpu.CommandBuffer.Descriptor) *dgpu.CommandBuffer {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         const command_buffer = command_encoder.finish(descriptor orelse &.{}) catch unreachable;
         command_buffer.manager.reference();
         return @ptrCast(command_buffer);
     }
 
-    pub inline fn commandEncoderInjectValidationError(command_encoder: *gpu.CommandEncoder, message: [*:0]const u8) void {
+    pub inline fn commandEncoderInjectValidationError(command_encoder: *dgpu.CommandEncoder, message: [*:0]const u8) void {
         _ = command_encoder;
         _ = message;
         unreachable;
     }
 
-    pub inline fn commandEncoderInsertDebugMarker(command_encoder: *gpu.CommandEncoder, marker_label: [*:0]const u8) void {
+    pub inline fn commandEncoderInsertDebugMarker(command_encoder: *dgpu.CommandEncoder, marker_label: [*:0]const u8) void {
         _ = command_encoder;
         _ = marker_label;
         unreachable;
     }
 
-    pub inline fn commandEncoderPopDebugGroup(command_encoder: *gpu.CommandEncoder) void {
+    pub inline fn commandEncoderPopDebugGroup(command_encoder: *dgpu.CommandEncoder) void {
         _ = command_encoder;
         unreachable;
     }
 
-    pub inline fn commandEncoderPushDebugGroup(command_encoder: *gpu.CommandEncoder, group_label: [*:0]const u8) void {
+    pub inline fn commandEncoderPushDebugGroup(command_encoder: *dgpu.CommandEncoder, group_label: [*:0]const u8) void {
         _ = command_encoder;
         _ = group_label;
         unreachable;
     }
 
-    pub inline fn commandEncoderResolveQuerySet(command_encoder: *gpu.CommandEncoder, query_set: *gpu.QuerySet, first_query: u32, query_count: u32, destination: *gpu.Buffer, destination_offset: u64) void {
+    pub inline fn commandEncoderResolveQuerySet(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, first_query: u32, query_count: u32, destination: *dgpu.Buffer, destination_offset: u64) void {
         _ = command_encoder;
         _ = query_set;
         _ = first_query;
@@ -303,13 +302,13 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderSetLabel(command_encoder: *gpu.CommandEncoder, label: [*:0]const u8) void {
+    pub inline fn commandEncoderSetLabel(command_encoder: *dgpu.CommandEncoder, label: [*:0]const u8) void {
         _ = command_encoder;
         _ = label;
         unreachable;
     }
 
-    pub inline fn commandEncoderWriteBuffer(command_encoder: *gpu.CommandEncoder, buffer: *gpu.Buffer, buffer_offset: u64, data: [*]const u8, size: u64) void {
+    pub inline fn commandEncoderWriteBuffer(command_encoder: *dgpu.CommandEncoder, buffer: *dgpu.Buffer, buffer_offset: u64, data: [*]const u8, size: u64) void {
         _ = command_encoder;
         _ = buffer;
         _ = buffer_offset;
@@ -318,146 +317,146 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn commandEncoderWriteTimestamp(command_encoder: *gpu.CommandEncoder, query_set: *gpu.QuerySet, query_index: u32) void {
+    pub inline fn commandEncoderWriteTimestamp(command_encoder: *dgpu.CommandEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
         _ = command_encoder;
         _ = query_set;
         _ = query_index;
         unreachable;
     }
 
-    pub inline fn commandEncoderReference(command_encoder_raw: *gpu.CommandEncoder) void {
+    pub inline fn commandEncoderReference(command_encoder_raw: *dgpu.CommandEncoder) void {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         command_encoder.manager.reference();
     }
 
-    pub inline fn commandEncoderRelease(command_encoder_raw: *gpu.CommandEncoder) void {
+    pub inline fn commandEncoderRelease(command_encoder_raw: *dgpu.CommandEncoder) void {
         const command_encoder: *impl.CommandEncoder = @ptrCast(@alignCast(command_encoder_raw));
         command_encoder.manager.release();
     }
 
-    pub inline fn computePassEncoderDispatchWorkgroups(compute_pass_encoder_raw: *gpu.ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void {
+    pub inline fn computePassEncoderDispatchWorkgroups(compute_pass_encoder_raw: *dgpu.ComputePassEncoder, workgroup_count_x: u32, workgroup_count_y: u32, workgroup_count_z: u32) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         compute_pass_encoder.dispatchWorkgroups(workgroup_count_x, workgroup_count_y, workgroup_count_z);
     }
 
-    pub inline fn computePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder: *gpu.ComputePassEncoder, indirect_buffer: *gpu.Buffer, indirect_offset: u64) void {
+    pub inline fn computePassEncoderDispatchWorkgroupsIndirect(compute_pass_encoder: *dgpu.ComputePassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
         _ = compute_pass_encoder;
         _ = indirect_buffer;
         _ = indirect_offset;
         unreachable;
     }
 
-    pub inline fn computePassEncoderEnd(compute_pass_encoder_raw: *gpu.ComputePassEncoder) void {
+    pub inline fn computePassEncoderEnd(compute_pass_encoder_raw: *dgpu.ComputePassEncoder) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         compute_pass_encoder.end();
     }
 
-    pub inline fn computePassEncoderInsertDebugMarker(compute_pass_encoder: *gpu.ComputePassEncoder, marker_label: [*:0]const u8) void {
+    pub inline fn computePassEncoderInsertDebugMarker(compute_pass_encoder: *dgpu.ComputePassEncoder, marker_label: [*:0]const u8) void {
         _ = compute_pass_encoder;
         _ = marker_label;
         unreachable;
     }
 
-    pub inline fn computePassEncoderPopDebugGroup(compute_pass_encoder: *gpu.ComputePassEncoder) void {
+    pub inline fn computePassEncoderPopDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder) void {
         _ = compute_pass_encoder;
         unreachable;
     }
 
-    pub inline fn computePassEncoderPushDebugGroup(compute_pass_encoder: *gpu.ComputePassEncoder, group_label: [*:0]const u8) void {
+    pub inline fn computePassEncoderPushDebugGroup(compute_pass_encoder: *dgpu.ComputePassEncoder, group_label: [*:0]const u8) void {
         _ = compute_pass_encoder;
         _ = group_label;
         unreachable;
     }
 
-    pub inline fn computePassEncoderSetBindGroup(compute_pass_encoder_raw: *gpu.ComputePassEncoder, group_index: u32, group_raw: *gpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+    pub inline fn computePassEncoderSetBindGroup(compute_pass_encoder_raw: *dgpu.ComputePassEncoder, group_index: u32, group_raw: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         const group: *impl.BindGroup = @ptrCast(@alignCast(group_raw));
         compute_pass_encoder.setBindGroup(group_index, group, dynamic_offset_count, dynamic_offsets) catch unreachable;
     }
 
-    pub inline fn computePassEncoderSetLabel(compute_pass_encoder: *gpu.ComputePassEncoder, label: [*:0]const u8) void {
+    pub inline fn computePassEncoderSetLabel(compute_pass_encoder: *dgpu.ComputePassEncoder, label: [*:0]const u8) void {
         _ = compute_pass_encoder;
         _ = label;
         unreachable;
     }
 
-    pub inline fn computePassEncoderSetPipeline(compute_pass_encoder_raw: *gpu.ComputePassEncoder, pipeline_raw: *gpu.ComputePipeline) void {
+    pub inline fn computePassEncoderSetPipeline(compute_pass_encoder_raw: *dgpu.ComputePassEncoder, pipeline_raw: *dgpu.ComputePipeline) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         const pipeline: *impl.ComputePipeline = @ptrCast(@alignCast(pipeline_raw));
         compute_pass_encoder.setPipeline(pipeline) catch unreachable;
     }
 
-    pub inline fn computePassEncoderWriteTimestamp(compute_pass_encoder: *gpu.ComputePassEncoder, query_set: *gpu.QuerySet, query_index: u32) void {
+    pub inline fn computePassEncoderWriteTimestamp(compute_pass_encoder: *dgpu.ComputePassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
         _ = compute_pass_encoder;
         _ = query_set;
         _ = query_index;
         unreachable;
     }
 
-    pub inline fn computePassEncoderReference(compute_pass_encoder_raw: *gpu.ComputePassEncoder) void {
+    pub inline fn computePassEncoderReference(compute_pass_encoder_raw: *dgpu.ComputePassEncoder) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         compute_pass_encoder.manager.reference();
     }
 
-    pub inline fn computePassEncoderRelease(compute_pass_encoder_raw: *gpu.ComputePassEncoder) void {
+    pub inline fn computePassEncoderRelease(compute_pass_encoder_raw: *dgpu.ComputePassEncoder) void {
         const compute_pass_encoder: *impl.ComputePassEncoder = @ptrCast(@alignCast(compute_pass_encoder_raw));
         compute_pass_encoder.manager.release();
     }
 
-    pub inline fn computePipelineGetBindGroupLayout(compute_pipeline_raw: *gpu.ComputePipeline, group_index: u32) *gpu.BindGroupLayout {
+    pub inline fn computePipelineGetBindGroupLayout(compute_pipeline_raw: *dgpu.ComputePipeline, group_index: u32) *dgpu.BindGroupLayout {
         const compute_pipeline: *impl.ComputePipeline = @ptrCast(@alignCast(compute_pipeline_raw));
         const layout = compute_pipeline.getBindGroupLayout(group_index);
         layout.manager.reference();
         return @ptrCast(layout);
     }
 
-    pub inline fn computePipelineSetLabel(compute_pipeline: *gpu.ComputePipeline, label: [*:0]const u8) void {
+    pub inline fn computePipelineSetLabel(compute_pipeline: *dgpu.ComputePipeline, label: [*:0]const u8) void {
         _ = compute_pipeline;
         _ = label;
         unreachable;
     }
 
-    pub inline fn computePipelineReference(compute_pipeline_raw: *gpu.ComputePipeline) void {
+    pub inline fn computePipelineReference(compute_pipeline_raw: *dgpu.ComputePipeline) void {
         const compute_pipeline: *impl.ComputePipeline = @ptrCast(@alignCast(compute_pipeline_raw));
         compute_pipeline.manager.reference();
     }
 
-    pub inline fn computePipelineRelease(compute_pipeline_raw: *gpu.ComputePipeline) void {
+    pub inline fn computePipelineRelease(compute_pipeline_raw: *dgpu.ComputePipeline) void {
         const compute_pipeline: *impl.ComputePipeline = @ptrCast(@alignCast(compute_pipeline_raw));
         compute_pipeline.manager.release();
     }
 
-    pub inline fn deviceCreateBindGroup(device_raw: *gpu.Device, descriptor: *const gpu.BindGroup.Descriptor) *gpu.BindGroup {
+    pub inline fn deviceCreateBindGroup(device_raw: *dgpu.Device, descriptor: *const dgpu.BindGroup.Descriptor) *dgpu.BindGroup {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const group = device.createBindGroup(descriptor) catch unreachable;
         return @ptrCast(group);
     }
 
-    pub inline fn deviceCreateBindGroupLayout(device_raw: *gpu.Device, descriptor: *const gpu.BindGroupLayout.Descriptor) *gpu.BindGroupLayout {
+    pub inline fn deviceCreateBindGroupLayout(device_raw: *dgpu.Device, descriptor: *const dgpu.BindGroupLayout.Descriptor) *dgpu.BindGroupLayout {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const layout = device.createBindGroupLayout(descriptor) catch unreachable;
         return @ptrCast(layout);
     }
 
-    pub inline fn deviceCreateBuffer(device_raw: *gpu.Device, descriptor: *const gpu.Buffer.Descriptor) *gpu.Buffer {
+    pub inline fn deviceCreateBuffer(device_raw: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const buffer = device.createBuffer(descriptor) catch unreachable;
         return @ptrCast(buffer);
     }
 
-    pub inline fn deviceCreateCommandEncoder(device_raw: *gpu.Device, descriptor: ?*const gpu.CommandEncoder.Descriptor) *gpu.CommandEncoder {
+    pub inline fn deviceCreateCommandEncoder(device_raw: *dgpu.Device, descriptor: ?*const dgpu.CommandEncoder.Descriptor) *dgpu.CommandEncoder {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const command_encoder = device.createCommandEncoder(descriptor orelse &.{}) catch unreachable;
         return @ptrCast(command_encoder);
     }
 
-    pub inline fn deviceCreateComputePipeline(device_raw: *gpu.Device, descriptor: *const gpu.ComputePipeline.Descriptor) *gpu.ComputePipeline {
+    pub inline fn deviceCreateComputePipeline(device_raw: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor) *dgpu.ComputePipeline {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const pipeline = device.createComputePipeline(descriptor) catch unreachable;
         return @ptrCast(pipeline);
     }
 
-    pub inline fn deviceCreateComputePipelineAsync(device: *gpu.Device, descriptor: *const gpu.ComputePipeline.Descriptor, callback: gpu.CreateComputePipelineAsyncCallback, userdata: ?*anyopaque) void {
+    pub inline fn deviceCreateComputePipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.ComputePipeline.Descriptor, callback: dgpu.CreateComputePipelineAsyncCallback, userdata: ?*anyopaque) void {
         _ = device;
         _ = descriptor;
         _ = callback;
@@ -465,54 +464,54 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn deviceCreateErrorBuffer(device: *gpu.Device, descriptor: *const gpu.Buffer.Descriptor) *gpu.Buffer {
+    pub inline fn deviceCreateErrorBuffer(device: *dgpu.Device, descriptor: *const dgpu.Buffer.Descriptor) *dgpu.Buffer {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreateErrorExternalTexture(device: *gpu.Device) *gpu.ExternalTexture {
+    pub inline fn deviceCreateErrorExternalTexture(device: *dgpu.Device) *dgpu.ExternalTexture {
         _ = device;
         unreachable;
     }
 
-    pub inline fn deviceCreateErrorTexture(device: *gpu.Device, descriptor: *const gpu.Texture.Descriptor) *gpu.Texture {
+    pub inline fn deviceCreateErrorTexture(device: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreateExternalTexture(device: *gpu.Device, external_texture_descriptor: *const gpu.ExternalTexture.Descriptor) *gpu.ExternalTexture {
+    pub inline fn deviceCreateExternalTexture(device: *dgpu.Device, external_texture_descriptor: *const dgpu.ExternalTexture.Descriptor) *dgpu.ExternalTexture {
         _ = device;
         _ = external_texture_descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreatePipelineLayout(device_raw: *gpu.Device, pipeline_layout_descriptor: *const gpu.PipelineLayout.Descriptor) *gpu.PipelineLayout {
+    pub inline fn deviceCreatePipelineLayout(device_raw: *dgpu.Device, pipeline_layout_descriptor: *const dgpu.PipelineLayout.Descriptor) *dgpu.PipelineLayout {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const layout = device.createPipelineLayout(pipeline_layout_descriptor) catch unreachable;
         return @ptrCast(layout);
     }
 
-    pub inline fn deviceCreateQuerySet(device: *gpu.Device, descriptor: *const gpu.QuerySet.Descriptor) *gpu.QuerySet {
+    pub inline fn deviceCreateQuerySet(device: *dgpu.Device, descriptor: *const dgpu.QuerySet.Descriptor) *dgpu.QuerySet {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreateRenderBundleEncoder(device: *gpu.Device, descriptor: *const gpu.RenderBundleEncoder.Descriptor) *gpu.RenderBundleEncoder {
+    pub inline fn deviceCreateRenderBundleEncoder(device: *dgpu.Device, descriptor: *const dgpu.RenderBundleEncoder.Descriptor) *dgpu.RenderBundleEncoder {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreateRenderPipeline(device_raw: *gpu.Device, descriptor: *const gpu.RenderPipeline.Descriptor) *gpu.RenderPipeline {
+    pub inline fn deviceCreateRenderPipeline(device_raw: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor) *dgpu.RenderPipeline {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const render_pipeline = device.createRenderPipeline(descriptor) catch unreachable;
         return @ptrCast(render_pipeline);
     }
 
-    pub inline fn deviceCreateRenderPipelineAsync(device: *gpu.Device, descriptor: *const gpu.RenderPipeline.Descriptor, callback: gpu.CreateRenderPipelineAsyncCallback, userdata: ?*anyopaque) void {
+    pub inline fn deviceCreateRenderPipelineAsync(device: *dgpu.Device, descriptor: *const dgpu.RenderPipeline.Descriptor, callback: dgpu.CreateRenderPipelineAsyncCallback, userdata: ?*anyopaque) void {
         _ = device;
         _ = descriptor;
         _ = callback;
@@ -520,18 +519,18 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub fn deviceCreateSampler(device: *gpu.Device, descriptor: ?*const gpu.Sampler.Descriptor) *gpu.Sampler {
+    pub fn deviceCreateSampler(device: *dgpu.Device, descriptor: ?*const dgpu.Sampler.Descriptor) *dgpu.Sampler {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceCreateShaderModule(device_raw: *gpu.Device, descriptor: *const gpu.ShaderModule.Descriptor) *gpu.ShaderModule {
+    pub inline fn deviceCreateShaderModule(device_raw: *dgpu.Device, descriptor: *const dgpu.ShaderModule.Descriptor) *dgpu.ShaderModule {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
 
         var errors = try shader.ErrorList.init(allocator);
         defer errors.deinit();
-        if (utils.findChained(gpu.ShaderModule.WGSLDescriptor, descriptor.next_in_chain.generic)) |wgsl_descriptor| {
+        if (utils.findChained(dgpu.ShaderModule.WGSLDescriptor, descriptor.next_in_chain.generic)) |wgsl_descriptor| {
             const source = std.mem.span(wgsl_descriptor.code);
 
             var ast = shader.Ast.parse(allocator, &errors, source) catch |err| switch (err) {
@@ -554,7 +553,7 @@ pub const Impl = struct {
 
             const shader_module = device.createShaderModuleAir(&air) catch unreachable;
             return @ptrCast(shader_module);
-        } else if (utils.findChained(gpu.ShaderModule.SPIRVDescriptor, descriptor.next_in_chain.generic)) |spirv_descriptor| {
+        } else if (utils.findChained(dgpu.ShaderModule.SPIRVDescriptor, descriptor.next_in_chain.generic)) |spirv_descriptor| {
             const output = std.mem.sliceAsBytes(spirv_descriptor.code[0..spirv_descriptor.code_size]);
             const shader_module = device.createShaderModuleSpirv(output) catch unreachable;
             return @ptrCast(shader_module);
@@ -563,232 +562,232 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn deviceCreateSwapChain(device_raw: *gpu.Device, surface_raw: ?*gpu.Surface, descriptor: *const gpu.SwapChain.Descriptor) *gpu.SwapChain {
+    pub inline fn deviceCreateSwapChain(device_raw: *dgpu.Device, surface_raw: ?*dgpu.Surface, descriptor: *const dgpu.SwapChain.Descriptor) *dgpu.SwapChain {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const surface: *impl.Surface = @ptrCast(@alignCast(surface_raw.?));
         const swapchain = device.createSwapChain(surface, descriptor) catch unreachable;
         return @ptrCast(swapchain);
     }
 
-    pub inline fn deviceCreateTexture(device_raw: *gpu.Device, descriptor: *const gpu.Texture.Descriptor) *gpu.Texture {
+    pub inline fn deviceCreateTexture(device_raw: *dgpu.Device, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const texture = device.createTexture(descriptor) catch unreachable;
         return @ptrCast(texture);
     }
 
-    pub inline fn deviceDestroy(device: *gpu.Device) void {
+    pub inline fn deviceDestroy(device: *dgpu.Device) void {
         _ = device;
         unreachable;
     }
 
-    pub inline fn deviceEnumerateFeatures(device: *gpu.Device, features: ?[*]gpu.FeatureName) usize {
+    pub inline fn deviceEnumerateFeatures(device: *dgpu.Device, features: ?[*]dgpu.FeatureName) usize {
         _ = device;
         _ = features;
         unreachable;
     }
 
-    pub inline fn deviceGetLimits(device: *gpu.Device, limits: *gpu.SupportedLimits) u32 {
+    pub inline fn deviceGetLimits(device: *dgpu.Device, limits: *dgpu.SupportedLimits) u32 {
         _ = device;
         _ = limits;
         unreachable;
     }
 
-    pub inline fn deviceGetQueue(device_raw: *gpu.Device) *gpu.Queue {
+    pub inline fn deviceGetQueue(device_raw: *dgpu.Device) *dgpu.Queue {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         const queue = device.getQueue() catch unreachable;
         queue.manager.reference();
         return @ptrCast(queue);
     }
 
-    pub inline fn deviceHasFeature(device: *gpu.Device, feature: gpu.FeatureName) u32 {
+    pub inline fn deviceHasFeature(device: *dgpu.Device, feature: dgpu.FeatureName) u32 {
         _ = device;
         _ = feature;
         unreachable;
     }
 
-    pub inline fn deviceImportSharedFence(device: *gpu.Device, descriptor: *const gpu.SharedFence.Descriptor) *gpu.SharedFence {
+    pub inline fn deviceImportSharedFence(device: *dgpu.Device, descriptor: *const dgpu.SharedFence.Descriptor) *dgpu.SharedFence {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceImportSharedTextureMemory(device: *gpu.Device, descriptor: *const gpu.SharedTextureMemory.Descriptor) *gpu.SharedTextureMemory {
+    pub inline fn deviceImportSharedTextureMemory(device: *dgpu.Device, descriptor: *const dgpu.SharedTextureMemory.Descriptor) *dgpu.SharedTextureMemory {
         _ = device;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn deviceInjectError(device: *gpu.Device, typ: gpu.ErrorType, message: [*:0]const u8) void {
+    pub inline fn deviceInjectError(device: *dgpu.Device, typ: dgpu.ErrorType, message: [*:0]const u8) void {
         _ = device;
         _ = typ;
         _ = message;
         unreachable;
     }
 
-    pub inline fn deviceLoseForTesting(device: *gpu.Device) void {
+    pub inline fn deviceLoseForTesting(device: *dgpu.Device) void {
         _ = device;
         unreachable;
     }
 
-    pub inline fn devicePopErrorScope(device: *gpu.Device, callback: gpu.ErrorCallback, userdata: ?*anyopaque) void {
+    pub inline fn devicePopErrorScope(device: *dgpu.Device, callback: dgpu.ErrorCallback, userdata: ?*anyopaque) void {
         _ = device;
         _ = callback;
         _ = userdata;
         unreachable;
     }
 
-    pub inline fn devicePushErrorScope(device: *gpu.Device, filter: gpu.ErrorFilter) void {
+    pub inline fn devicePushErrorScope(device: *dgpu.Device, filter: dgpu.ErrorFilter) void {
         _ = device;
         _ = filter;
         unreachable;
     }
 
-    pub inline fn deviceSetDeviceLostCallback(device_raw: *gpu.Device, callback: ?gpu.Device.LostCallback, userdata: ?*anyopaque) void {
+    pub inline fn deviceSetDeviceLostCallback(device_raw: *dgpu.Device, callback: ?dgpu.Device.LostCallback, userdata: ?*anyopaque) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.lost_cb = callback;
         device.lost_cb_userdata = userdata;
     }
 
-    pub inline fn deviceSetLabel(device: *gpu.Device, label: [*:0]const u8) void {
+    pub inline fn deviceSetLabel(device: *dgpu.Device, label: [*:0]const u8) void {
         _ = device;
         _ = label;
         unreachable;
     }
 
-    pub inline fn deviceSetLoggingCallback(device_raw: *gpu.Device, callback: ?gpu.LoggingCallback, userdata: ?*anyopaque) void {
+    pub inline fn deviceSetLoggingCallback(device_raw: *dgpu.Device, callback: ?dgpu.LoggingCallback, userdata: ?*anyopaque) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.log_cb = callback;
         device.log_cb_userdata = userdata;
     }
 
-    pub inline fn deviceSetUncapturedErrorCallback(device_raw: *gpu.Device, callback: ?gpu.ErrorCallback, userdata: ?*anyopaque) void {
+    pub inline fn deviceSetUncapturedErrorCallback(device_raw: *dgpu.Device, callback: ?dgpu.ErrorCallback, userdata: ?*anyopaque) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.err_cb = callback;
         device.err_cb_userdata = userdata;
     }
 
-    pub inline fn deviceTick(device_raw: *gpu.Device) void {
+    pub inline fn deviceTick(device_raw: *dgpu.Device) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.tick() catch unreachable;
     }
 
-    pub inline fn machDeviceWaitForCommandsToBeScheduled(device: *gpu.Device) void {
+    pub inline fn machDeviceWaitForCommandsToBeScheduled(device: *dgpu.Device) void {
         _ = device;
     }
 
-    pub inline fn deviceReference(device_raw: *gpu.Device) void {
+    pub inline fn deviceReference(device_raw: *dgpu.Device) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.manager.reference();
     }
 
-    pub inline fn deviceRelease(device_raw: *gpu.Device) void {
+    pub inline fn deviceRelease(device_raw: *dgpu.Device) void {
         const device: *impl.Device = @ptrCast(@alignCast(device_raw));
         device.manager.release();
     }
 
-    pub inline fn externalTextureDestroy(external_texture: *gpu.ExternalTexture) void {
+    pub inline fn externalTextureDestroy(external_texture: *dgpu.ExternalTexture) void {
         _ = external_texture;
         unreachable;
     }
 
-    pub inline fn externalTextureSetLabel(external_texture: *gpu.ExternalTexture, label: [*:0]const u8) void {
+    pub inline fn externalTextureSetLabel(external_texture: *dgpu.ExternalTexture, label: [*:0]const u8) void {
         _ = external_texture;
         _ = label;
         unreachable;
     }
 
-    pub inline fn externalTextureReference(external_texture: *gpu.ExternalTexture) void {
+    pub inline fn externalTextureReference(external_texture: *dgpu.ExternalTexture) void {
         _ = external_texture;
         unreachable;
     }
 
-    pub inline fn externalTextureRelease(external_texture: *gpu.ExternalTexture) void {
+    pub inline fn externalTextureRelease(external_texture: *dgpu.ExternalTexture) void {
         _ = external_texture;
         unreachable;
     }
 
-    pub inline fn instanceCreateSurface(instance_raw: *gpu.Instance, descriptor: *const gpu.Surface.Descriptor) *gpu.Surface {
+    pub inline fn instanceCreateSurface(instance_raw: *dgpu.Instance, descriptor: *const dgpu.Surface.Descriptor) *dgpu.Surface {
         const instance: *impl.Instance = @ptrCast(@alignCast(instance_raw));
         const surface = instance.createSurface(descriptor) catch unreachable;
         return @ptrCast(surface);
     }
 
-    pub inline fn instanceProcessEvents(instance: *gpu.Instance) void {
+    pub inline fn instanceProcessEvents(instance: *dgpu.Instance) void {
         _ = instance;
         unreachable;
     }
 
     pub inline fn instanceRequestAdapter(
-        instance_raw: *gpu.Instance,
-        options: ?*const gpu.RequestAdapterOptions,
-        callback: gpu.RequestAdapterCallback,
+        instance_raw: *dgpu.Instance,
+        options: ?*const dgpu.RequestAdapterOptions,
+        callback: dgpu.RequestAdapterCallback,
         userdata: ?*anyopaque,
     ) void {
         const instance: *impl.Instance = @ptrCast(@alignCast(instance_raw));
-        const adapter = impl.Adapter.init(instance, options orelse &gpu.RequestAdapterOptions{}) catch |err| {
+        const adapter = impl.Adapter.init(instance, options orelse &dgpu.RequestAdapterOptions{}) catch |err| {
             return callback(.err, undefined, @errorName(err), userdata);
         };
-        callback(.success, @as(*gpu.Adapter, @ptrCast(adapter)), null, userdata);
+        callback(.success, @as(*dgpu.Adapter, @ptrCast(adapter)), null, userdata);
     }
 
-    pub inline fn instanceReference(instance_raw: *gpu.Instance) void {
+    pub inline fn instanceReference(instance_raw: *dgpu.Instance) void {
         const instance: *impl.Instance = @ptrCast(@alignCast(instance_raw));
         instance.manager.reference();
     }
 
-    pub inline fn instanceRelease(instance_raw: *gpu.Instance) void {
+    pub inline fn instanceRelease(instance_raw: *dgpu.Instance) void {
         const instance: *impl.Instance = @ptrCast(@alignCast(instance_raw));
         instance.manager.release();
     }
 
-    pub inline fn pipelineLayoutSetLabel(pipeline_layout: *gpu.PipelineLayout, label: [*:0]const u8) void {
+    pub inline fn pipelineLayoutSetLabel(pipeline_layout: *dgpu.PipelineLayout, label: [*:0]const u8) void {
         _ = pipeline_layout;
         _ = label;
         unreachable;
     }
 
-    pub inline fn pipelineLayoutReference(pipeline_layout_raw: *gpu.PipelineLayout) void {
+    pub inline fn pipelineLayoutReference(pipeline_layout_raw: *dgpu.PipelineLayout) void {
         const pipeline_layout: *impl.PipelineLayout = @ptrCast(@alignCast(pipeline_layout_raw));
         pipeline_layout.manager.reference();
     }
 
-    pub inline fn pipelineLayoutRelease(pipeline_layout_raw: *gpu.PipelineLayout) void {
+    pub inline fn pipelineLayoutRelease(pipeline_layout_raw: *dgpu.PipelineLayout) void {
         const pipeline_layout: *impl.PipelineLayout = @ptrCast(@alignCast(pipeline_layout_raw));
         pipeline_layout.manager.release();
     }
 
-    pub inline fn querySetDestroy(query_set: *gpu.QuerySet) void {
+    pub inline fn querySetDestroy(query_set: *dgpu.QuerySet) void {
         _ = query_set;
         unreachable;
     }
 
-    pub inline fn querySetGetCount(query_set: *gpu.QuerySet) u32 {
+    pub inline fn querySetGetCount(query_set: *dgpu.QuerySet) u32 {
         _ = query_set;
         unreachable;
     }
 
-    pub inline fn querySetGetType(query_set: *gpu.QuerySet) gpu.QueryType {
+    pub inline fn querySetGetType(query_set: *dgpu.QuerySet) dgpu.QueryType {
         _ = query_set;
         unreachable;
     }
 
-    pub inline fn querySetSetLabel(query_set: *gpu.QuerySet, label: [*:0]const u8) void {
+    pub inline fn querySetSetLabel(query_set: *dgpu.QuerySet, label: [*:0]const u8) void {
         _ = query_set;
         _ = label;
         unreachable;
     }
 
-    pub inline fn querySetReference(query_set: *gpu.QuerySet) void {
+    pub inline fn querySetReference(query_set: *dgpu.QuerySet) void {
         _ = query_set;
         unreachable;
     }
 
-    pub inline fn querySetRelease(query_set: *gpu.QuerySet) void {
+    pub inline fn querySetRelease(query_set: *dgpu.QuerySet) void {
         _ = query_set;
         unreachable;
     }
 
-    pub inline fn queueCopyTextureForBrowser(queue: *gpu.Queue, source: *const gpu.ImageCopyTexture, destination: *const gpu.ImageCopyTexture, copy_size: *const gpu.Extent3D, options: *const gpu.CopyTextureForBrowserOptions) void {
+    pub inline fn queueCopyTextureForBrowser(queue: *dgpu.Queue, source: *const dgpu.ImageCopyTexture, destination: *const dgpu.ImageCopyTexture, copy_size: *const dgpu.Extent3D, options: *const dgpu.CopyTextureForBrowserOptions) void {
         _ = queue;
         _ = source;
         _ = destination;
@@ -797,7 +796,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn queueOnSubmittedWorkDone(queue: *gpu.Queue, signal_value: u64, callback: gpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) void {
+    pub inline fn queueOnSubmittedWorkDone(queue: *dgpu.Queue, signal_value: u64, callback: dgpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) void {
         _ = queue;
         _ = signal_value;
         _ = callback;
@@ -805,25 +804,25 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn queueSetLabel(queue: *gpu.Queue, label: [*:0]const u8) void {
+    pub inline fn queueSetLabel(queue: *dgpu.Queue, label: [*:0]const u8) void {
         _ = queue;
         _ = label;
         unreachable;
     }
 
-    pub inline fn queueSubmit(queue_raw: *gpu.Queue, command_count: usize, commands_raw: [*]const *const gpu.CommandBuffer) void {
+    pub inline fn queueSubmit(queue_raw: *dgpu.Queue, command_count: usize, commands_raw: [*]const *const dgpu.CommandBuffer) void {
         const queue: *impl.Queue = @ptrCast(@alignCast(queue_raw));
         const commands: []const *impl.CommandBuffer = @ptrCast(commands_raw[0..command_count]);
         queue.submit(commands) catch unreachable;
     }
 
-    pub inline fn queueWriteBuffer(queue_raw: *gpu.Queue, buffer_raw: *gpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) void {
+    pub inline fn queueWriteBuffer(queue_raw: *dgpu.Queue, buffer_raw: *dgpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) void {
         const queue: *impl.Queue = @ptrCast(@alignCast(queue_raw));
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         queue.writeBuffer(buffer, buffer_offset, @ptrCast(data), size) catch unreachable;
     }
 
-    pub inline fn queueWriteTexture(queue: *gpu.Queue, destination: *const gpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const gpu.Texture.DataLayout, write_size: *const gpu.Extent3D) void {
+    pub inline fn queueWriteTexture(queue: *dgpu.Queue, destination: *const dgpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const dgpu.Texture.DataLayout, write_size: *const dgpu.Extent3D) void {
         _ = queue;
         _ = destination;
         _ = data;
@@ -833,33 +832,33 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn queueReference(queue_raw: *gpu.Queue) void {
+    pub inline fn queueReference(queue_raw: *dgpu.Queue) void {
         const queue: *impl.Queue = @ptrCast(@alignCast(queue_raw));
         queue.manager.reference();
     }
 
-    pub inline fn queueRelease(queue_raw: *gpu.Queue) void {
+    pub inline fn queueRelease(queue_raw: *dgpu.Queue) void {
         const queue: *impl.Queue = @ptrCast(@alignCast(queue_raw));
         queue.manager.release();
     }
 
-    pub inline fn renderBundleReference(render_bundle: *gpu.RenderBundle) void {
+    pub inline fn renderBundleReference(render_bundle: *dgpu.RenderBundle) void {
         _ = render_bundle;
         unreachable;
     }
 
-    pub inline fn renderBundleRelease(render_bundle: *gpu.RenderBundle) void {
+    pub inline fn renderBundleRelease(render_bundle: *dgpu.RenderBundle) void {
         _ = render_bundle;
         unreachable;
     }
 
-    pub inline fn renderBundleSetLabel(render_bundle: *gpu.RenderBundle, name: [*:0]const u8) void {
+    pub inline fn renderBundleSetLabel(render_bundle: *dgpu.RenderBundle, name: [*:0]const u8) void {
         _ = name;
         _ = render_bundle;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderDraw(render_bundle_encoder: *gpu.RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+    pub inline fn renderBundleEncoderDraw(render_bundle_encoder: *dgpu.RenderBundleEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
         _ = render_bundle_encoder;
         _ = vertex_count;
         _ = instance_count;
@@ -868,7 +867,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderDrawIndexed(render_bundle_encoder: *gpu.RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+    pub inline fn renderBundleEncoderDrawIndexed(render_bundle_encoder: *dgpu.RenderBundleEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
         _ = render_bundle_encoder;
         _ = index_count;
         _ = instance_count;
@@ -878,44 +877,44 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderDrawIndexedIndirect(render_bundle_encoder: *gpu.RenderBundleEncoder, indirect_buffer: *gpu.Buffer, indirect_offset: u64) void {
+    pub inline fn renderBundleEncoderDrawIndexedIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
         _ = render_bundle_encoder;
         _ = indirect_buffer;
         _ = indirect_offset;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderDrawIndirect(render_bundle_encoder: *gpu.RenderBundleEncoder, indirect_buffer: *gpu.Buffer, indirect_offset: u64) void {
+    pub inline fn renderBundleEncoderDrawIndirect(render_bundle_encoder: *dgpu.RenderBundleEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
         _ = render_bundle_encoder;
         _ = indirect_buffer;
         _ = indirect_offset;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderFinish(render_bundle_encoder: *gpu.RenderBundleEncoder, descriptor: ?*const gpu.RenderBundle.Descriptor) *gpu.RenderBundle {
+    pub inline fn renderBundleEncoderFinish(render_bundle_encoder: *dgpu.RenderBundleEncoder, descriptor: ?*const dgpu.RenderBundle.Descriptor) *dgpu.RenderBundle {
         _ = render_bundle_encoder;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderInsertDebugMarker(render_bundle_encoder: *gpu.RenderBundleEncoder, marker_label: [*:0]const u8) void {
+    pub inline fn renderBundleEncoderInsertDebugMarker(render_bundle_encoder: *dgpu.RenderBundleEncoder, marker_label: [*:0]const u8) void {
         _ = render_bundle_encoder;
         _ = marker_label;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderPopDebugGroup(render_bundle_encoder: *gpu.RenderBundleEncoder) void {
+    pub inline fn renderBundleEncoderPopDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
         _ = render_bundle_encoder;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderPushDebugGroup(render_bundle_encoder: *gpu.RenderBundleEncoder, group_label: [*:0]const u8) void {
+    pub inline fn renderBundleEncoderPushDebugGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_label: [*:0]const u8) void {
         _ = render_bundle_encoder;
         _ = group_label;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderSetBindGroup(render_bundle_encoder: *gpu.RenderBundleEncoder, group_index: u32, group: *gpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
+    pub inline fn renderBundleEncoderSetBindGroup(render_bundle_encoder: *dgpu.RenderBundleEncoder, group_index: u32, group: *dgpu.BindGroup, dynamic_offset_count: usize, dynamic_offsets: ?[*]const u32) void {
         _ = render_bundle_encoder;
         _ = group_index;
         _ = group;
@@ -924,7 +923,7 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderSetIndexBuffer(render_bundle_encoder: *gpu.RenderBundleEncoder, buffer: *gpu.Buffer, format: gpu.IndexFormat, offset: u64, size: u64) void {
+    pub inline fn renderBundleEncoderSetIndexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
         _ = render_bundle_encoder;
         _ = buffer;
         _ = format;
@@ -933,19 +932,19 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderSetLabel(render_bundle_encoder: *gpu.RenderBundleEncoder, label: [*:0]const u8) void {
+    pub inline fn renderBundleEncoderSetLabel(render_bundle_encoder: *dgpu.RenderBundleEncoder, label: [*:0]const u8) void {
         _ = render_bundle_encoder;
         _ = label;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderSetPipeline(render_bundle_encoder: *gpu.RenderBundleEncoder, pipeline: *gpu.RenderPipeline) void {
+    pub inline fn renderBundleEncoderSetPipeline(render_bundle_encoder: *dgpu.RenderBundleEncoder, pipeline: *dgpu.RenderPipeline) void {
         _ = render_bundle_encoder;
         _ = pipeline;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderSetVertexBuffer(render_bundle_encoder: *gpu.RenderBundleEncoder, slot: u32, buffer: *gpu.Buffer, offset: u64, size: u64) void {
+    pub inline fn renderBundleEncoderSetVertexBuffer(render_bundle_encoder: *dgpu.RenderBundleEncoder, slot: u32, buffer: *dgpu.Buffer, offset: u64, size: u64) void {
         _ = render_bundle_encoder;
         _ = slot;
         _ = buffer;
@@ -954,28 +953,28 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderReference(render_bundle_encoder: *gpu.RenderBundleEncoder) void {
+    pub inline fn renderBundleEncoderReference(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
         _ = render_bundle_encoder;
         unreachable;
     }
 
-    pub inline fn renderBundleEncoderRelease(render_bundle_encoder: *gpu.RenderBundleEncoder) void {
+    pub inline fn renderBundleEncoderRelease(render_bundle_encoder: *dgpu.RenderBundleEncoder) void {
         _ = render_bundle_encoder;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderBeginOcclusionQuery(render_pass_encoder: *gpu.RenderPassEncoder, query_index: u32) void {
+    pub inline fn renderPassEncoderBeginOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder, query_index: u32) void {
         _ = render_pass_encoder;
         _ = query_index;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderDraw(render_pass_encoder_raw: *gpu.RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
+    pub inline fn renderPassEncoderDraw(render_pass_encoder_raw: *dgpu.RenderPassEncoder, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         render_pass_encoder.draw(vertex_count, instance_count, first_vertex, first_instance);
     }
 
-    pub inline fn renderPassEncoderDrawIndexed(render_pass_encoder: *gpu.RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
+    pub inline fn renderPassEncoderDrawIndexed(render_pass_encoder: *dgpu.RenderPassEncoder, index_count: u32, instance_count: u32, first_index: u32, base_vertex: i32, first_instance: u32) void {
         _ = render_pass_encoder;
         _ = index_count;
         _ = instance_count;
@@ -985,58 +984,58 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderPassEncoderDrawIndexedIndirect(render_pass_encoder: *gpu.RenderPassEncoder, indirect_buffer: *gpu.Buffer, indirect_offset: u64) void {
+    pub inline fn renderPassEncoderDrawIndexedIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
         _ = render_pass_encoder;
         _ = indirect_buffer;
         _ = indirect_offset;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderDrawIndirect(render_pass_encoder: *gpu.RenderPassEncoder, indirect_buffer: *gpu.Buffer, indirect_offset: u64) void {
+    pub inline fn renderPassEncoderDrawIndirect(render_pass_encoder: *dgpu.RenderPassEncoder, indirect_buffer: *dgpu.Buffer, indirect_offset: u64) void {
         _ = render_pass_encoder;
         _ = indirect_buffer;
         _ = indirect_offset;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderEnd(render_pass_encoder_raw: *gpu.RenderPassEncoder) void {
+    pub inline fn renderPassEncoderEnd(render_pass_encoder_raw: *dgpu.RenderPassEncoder) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         render_pass_encoder.end();
     }
 
-    pub inline fn renderPassEncoderEndOcclusionQuery(render_pass_encoder: *gpu.RenderPassEncoder) void {
+    pub inline fn renderPassEncoderEndOcclusionQuery(render_pass_encoder: *dgpu.RenderPassEncoder) void {
         _ = render_pass_encoder;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderExecuteBundles(render_pass_encoder: *gpu.RenderPassEncoder, bundles_count: usize, bundles: [*]const *const gpu.RenderBundle) void {
+    pub inline fn renderPassEncoderExecuteBundles(render_pass_encoder: *dgpu.RenderPassEncoder, bundles_count: usize, bundles: [*]const *const dgpu.RenderBundle) void {
         _ = render_pass_encoder;
         _ = bundles_count;
         _ = bundles;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderInsertDebugMarker(render_pass_encoder: *gpu.RenderPassEncoder, marker_label: [*:0]const u8) void {
+    pub inline fn renderPassEncoderInsertDebugMarker(render_pass_encoder: *dgpu.RenderPassEncoder, marker_label: [*:0]const u8) void {
         _ = render_pass_encoder;
         _ = marker_label;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderPopDebugGroup(render_pass_encoder: *gpu.RenderPassEncoder) void {
+    pub inline fn renderPassEncoderPopDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder) void {
         _ = render_pass_encoder;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderPushDebugGroup(render_pass_encoder: *gpu.RenderPassEncoder, group_label: [*:0]const u8) void {
+    pub inline fn renderPassEncoderPushDebugGroup(render_pass_encoder: *dgpu.RenderPassEncoder, group_label: [*:0]const u8) void {
         _ = render_pass_encoder;
         _ = group_label;
         unreachable;
     }
 
     pub inline fn renderPassEncoderSetBindGroup(
-        render_pass_encoder_raw: *gpu.RenderPassEncoder,
+        render_pass_encoder_raw: *dgpu.RenderPassEncoder,
         group_index: u32,
-        group_raw: *gpu.BindGroup,
+        group_raw: *dgpu.BindGroup,
         dynamic_offset_count: usize,
         dynamic_offsets: ?[*]const u32,
     ) void {
@@ -1045,13 +1044,13 @@ pub const Impl = struct {
         render_pass_encoder.setBindGroup(group_index, group, dynamic_offset_count, dynamic_offsets) catch unreachable;
     }
 
-    pub inline fn renderPassEncoderSetBlendConstant(render_pass_encoder: *gpu.RenderPassEncoder, color: *const gpu.Color) void {
+    pub inline fn renderPassEncoderSetBlendConstant(render_pass_encoder: *dgpu.RenderPassEncoder, color: *const dgpu.Color) void {
         _ = render_pass_encoder;
         _ = color;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderSetIndexBuffer(render_pass_encoder: *gpu.RenderPassEncoder, buffer: *gpu.Buffer, format: gpu.IndexFormat, offset: u64, size: u64) void {
+    pub inline fn renderPassEncoderSetIndexBuffer(render_pass_encoder: *dgpu.RenderPassEncoder, buffer: *dgpu.Buffer, format: dgpu.IndexFormat, offset: u64, size: u64) void {
         _ = render_pass_encoder;
         _ = buffer;
         _ = format;
@@ -1060,19 +1059,19 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderPassEncoderSetLabel(render_pass_encoder: *gpu.RenderPassEncoder, label: [*:0]const u8) void {
+    pub inline fn renderPassEncoderSetLabel(render_pass_encoder: *dgpu.RenderPassEncoder, label: [*:0]const u8) void {
         _ = render_pass_encoder;
         _ = label;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderSetPipeline(render_pass_encoder_raw: *gpu.RenderPassEncoder, pipeline_raw: *gpu.RenderPipeline) void {
+    pub inline fn renderPassEncoderSetPipeline(render_pass_encoder_raw: *dgpu.RenderPassEncoder, pipeline_raw: *dgpu.RenderPipeline) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         const pipeline: *impl.RenderPipeline = @ptrCast(@alignCast(pipeline_raw));
         render_pass_encoder.setPipeline(pipeline) catch unreachable;
     }
 
-    pub inline fn renderPassEncoderSetScissorRect(render_pass_encoder: *gpu.RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) void {
+    pub inline fn renderPassEncoderSetScissorRect(render_pass_encoder: *dgpu.RenderPassEncoder, x: u32, y: u32, width: u32, height: u32) void {
         _ = render_pass_encoder;
         _ = x;
         _ = y;
@@ -1081,19 +1080,19 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderPassEncoderSetStencilReference(render_pass_encoder: *gpu.RenderPassEncoder, reference: u32) void {
+    pub inline fn renderPassEncoderSetStencilReference(render_pass_encoder: *dgpu.RenderPassEncoder, reference: u32) void {
         _ = render_pass_encoder;
         _ = reference;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderSetVertexBuffer(render_pass_encoder_raw: *gpu.RenderPassEncoder, slot: u32, buffer_raw: *gpu.Buffer, offset: u64, size: u64) void {
+    pub inline fn renderPassEncoderSetVertexBuffer(render_pass_encoder_raw: *dgpu.RenderPassEncoder, slot: u32, buffer_raw: *dgpu.Buffer, offset: u64, size: u64) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         const buffer: *impl.Buffer = @ptrCast(@alignCast(buffer_raw));
         render_pass_encoder.setVertexBuffer(slot, buffer, offset, size) catch unreachable;
     }
 
-    pub inline fn renderPassEncoderSetViewport(render_pass_encoder: *gpu.RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
+    pub inline fn renderPassEncoderSetViewport(render_pass_encoder: *dgpu.RenderPassEncoder, x: f32, y: f32, width: f32, height: f32, min_depth: f32, max_depth: f32) void {
         _ = render_pass_encoder;
         _ = x;
         _ = y;
@@ -1104,159 +1103,159 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn renderPassEncoderWriteTimestamp(render_pass_encoder: *gpu.RenderPassEncoder, query_set: *gpu.QuerySet, query_index: u32) void {
+    pub inline fn renderPassEncoderWriteTimestamp(render_pass_encoder: *dgpu.RenderPassEncoder, query_set: *dgpu.QuerySet, query_index: u32) void {
         _ = render_pass_encoder;
         _ = query_set;
         _ = query_index;
         unreachable;
     }
 
-    pub inline fn renderPassEncoderReference(render_pass_encoder_raw: *gpu.RenderPassEncoder) void {
+    pub inline fn renderPassEncoderReference(render_pass_encoder_raw: *dgpu.RenderPassEncoder) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         render_pass_encoder.manager.reference();
     }
 
-    pub inline fn renderPassEncoderRelease(render_pass_encoder_raw: *gpu.RenderPassEncoder) void {
+    pub inline fn renderPassEncoderRelease(render_pass_encoder_raw: *dgpu.RenderPassEncoder) void {
         const render_pass_encoder: *impl.RenderPassEncoder = @ptrCast(@alignCast(render_pass_encoder_raw));
         render_pass_encoder.manager.release();
     }
 
-    pub inline fn renderPipelineGetBindGroupLayout(render_pipeline_raw: *gpu.RenderPipeline, group_index: u32) *gpu.BindGroupLayout {
+    pub inline fn renderPipelineGetBindGroupLayout(render_pipeline_raw: *dgpu.RenderPipeline, group_index: u32) *dgpu.BindGroupLayout {
         const render_pipeline: *impl.RenderPipeline = @ptrCast(@alignCast(render_pipeline_raw));
         const layout: *impl.BindGroupLayout = render_pipeline.getBindGroupLayout(group_index);
         layout.manager.reference();
         return @ptrCast(layout);
     }
 
-    pub inline fn renderPipelineSetLabel(render_pipeline: *gpu.RenderPipeline, label: [*:0]const u8) void {
+    pub inline fn renderPipelineSetLabel(render_pipeline: *dgpu.RenderPipeline, label: [*:0]const u8) void {
         _ = render_pipeline;
         _ = label;
         unreachable;
     }
 
-    pub inline fn renderPipelineReference(render_pipeline_raw: *gpu.RenderPipeline) void {
+    pub inline fn renderPipelineReference(render_pipeline_raw: *dgpu.RenderPipeline) void {
         const render_pipeline: *impl.RenderPipeline = @ptrCast(@alignCast(render_pipeline_raw));
         render_pipeline.manager.reference();
     }
 
-    pub inline fn renderPipelineRelease(render_pipeline_raw: *gpu.RenderPipeline) void {
+    pub inline fn renderPipelineRelease(render_pipeline_raw: *dgpu.RenderPipeline) void {
         const render_pipeline: *impl.RenderPipeline = @ptrCast(@alignCast(render_pipeline_raw));
         render_pipeline.manager.release();
     }
 
-    pub inline fn samplerSetLabel(sampler: *gpu.Sampler, label: [*:0]const u8) void {
+    pub inline fn samplerSetLabel(sampler: *dgpu.Sampler, label: [*:0]const u8) void {
         _ = sampler;
         _ = label;
         unreachable;
     }
 
-    pub inline fn samplerReference(sampler: *gpu.Sampler) void {
+    pub inline fn samplerReference(sampler: *dgpu.Sampler) void {
         _ = sampler;
         unreachable;
     }
 
-    pub inline fn samplerRelease(sampler: *gpu.Sampler) void {
+    pub inline fn samplerRelease(sampler: *dgpu.Sampler) void {
         _ = sampler;
         unreachable;
     }
 
-    pub inline fn shaderModuleGetCompilationInfo(shader_module: *gpu.ShaderModule, callback: gpu.CompilationInfoCallback, userdata: ?*anyopaque) void {
+    pub inline fn shaderModuleGetCompilationInfo(shader_module: *dgpu.ShaderModule, callback: dgpu.CompilationInfoCallback, userdata: ?*anyopaque) void {
         _ = shader_module;
         _ = callback;
         _ = userdata;
         unreachable;
     }
 
-    pub inline fn shaderModuleSetLabel(shader_module: *gpu.ShaderModule, label: [*:0]const u8) void {
+    pub inline fn shaderModuleSetLabel(shader_module: *dgpu.ShaderModule, label: [*:0]const u8) void {
         _ = shader_module;
         _ = label;
         unreachable;
     }
 
-    pub inline fn shaderModuleReference(shader_module_raw: *gpu.ShaderModule) void {
+    pub inline fn shaderModuleReference(shader_module_raw: *dgpu.ShaderModule) void {
         const shader_module: *impl.ShaderModule = @ptrCast(@alignCast(shader_module_raw));
         shader_module.manager.reference();
     }
 
-    pub inline fn shaderModuleRelease(shader_module_raw: *gpu.ShaderModule) void {
+    pub inline fn shaderModuleRelease(shader_module_raw: *dgpu.ShaderModule) void {
         const shader_module: *impl.ShaderModule = @ptrCast(@alignCast(shader_module_raw));
         shader_module.manager.release();
     }
 
-    pub inline fn sharedFenceExportInfo(shared_fence: *gpu.SharedFence, info: *gpu.SharedFence.ExportInfo) void {
+    pub inline fn sharedFenceExportInfo(shared_fence: *dgpu.SharedFence, info: *dgpu.SharedFence.ExportInfo) void {
         _ = shared_fence;
         _ = info;
         unreachable;
     }
 
-    pub inline fn sharedFenceReference(shared_fence: *gpu.SharedFence) void {
+    pub inline fn sharedFenceReference(shared_fence: *dgpu.SharedFence) void {
         _ = shared_fence;
         unreachable;
     }
 
-    pub inline fn sharedFenceRelease(shared_fence: *gpu.SharedFence) void {
+    pub inline fn sharedFenceRelease(shared_fence: *dgpu.SharedFence) void {
         _ = shared_fence;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryBeginAccess(shared_texture_memory: *gpu.SharedTextureMemory, texture: *gpu.Texture, descriptor: *const gpu.SharedTextureMemory.BeginAccessDescriptor) void {
+    pub inline fn sharedTextureMemoryBeginAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *const dgpu.SharedTextureMemory.BeginAccessDescriptor) void {
         _ = shared_texture_memory;
         _ = texture;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryCreateTexture(shared_texture_memory: *gpu.SharedTextureMemory, descriptor: *const gpu.Texture.Descriptor) *gpu.Texture {
+    pub inline fn sharedTextureMemoryCreateTexture(shared_texture_memory: *dgpu.SharedTextureMemory, descriptor: *const dgpu.Texture.Descriptor) *dgpu.Texture {
         _ = shared_texture_memory;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryEndAccess(shared_texture_memory: *gpu.SharedTextureMemory, texture: *gpu.Texture, descriptor: *gpu.SharedTextureMemory.EndAccessState) void {
+    pub inline fn sharedTextureMemoryEndAccess(shared_texture_memory: *dgpu.SharedTextureMemory, texture: *dgpu.Texture, descriptor: *dgpu.SharedTextureMemory.EndAccessState) void {
         _ = shared_texture_memory;
         _ = texture;
         _ = descriptor;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryEndAccessStateFreeMembers(value: gpu.SharedTextureMemory.EndAccessState) void {
+    pub inline fn sharedTextureMemoryEndAccessStateFreeMembers(value: dgpu.SharedTextureMemory.EndAccessState) void {
         _ = value;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryGetProperties(shared_texture_memory: *gpu.SharedTextureMemory, properties: *gpu.SharedTextureMemory.Properties) void {
+    pub inline fn sharedTextureMemoryGetProperties(shared_texture_memory: *dgpu.SharedTextureMemory, properties: *dgpu.SharedTextureMemory.Properties) void {
         _ = shared_texture_memory;
         _ = properties;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemorySetLabel(shared_texture_memory: *gpu.SharedTextureMemory, label: [*:0]const u8) void {
+    pub inline fn sharedTextureMemorySetLabel(shared_texture_memory: *dgpu.SharedTextureMemory, label: [*:0]const u8) void {
         _ = shared_texture_memory;
         _ = label;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryReference(shared_texture_memory: *gpu.SharedTextureMemory) void {
+    pub inline fn sharedTextureMemoryReference(shared_texture_memory: *dgpu.SharedTextureMemory) void {
         _ = shared_texture_memory;
         unreachable;
     }
 
-    pub inline fn sharedTextureMemoryRelease(shared_texture_memory: *gpu.SharedTextureMemory) void {
+    pub inline fn sharedTextureMemoryRelease(shared_texture_memory: *dgpu.SharedTextureMemory) void {
         _ = shared_texture_memory;
         unreachable;
     }
 
-    pub inline fn surfaceReference(surface_raw: *gpu.Surface) void {
+    pub inline fn surfaceReference(surface_raw: *dgpu.Surface) void {
         const surface: *impl.Surface = @ptrCast(@alignCast(surface_raw));
         surface.manager.reference();
     }
 
-    pub inline fn surfaceRelease(surface_raw: *gpu.Surface) void {
+    pub inline fn surfaceRelease(surface_raw: *dgpu.Surface) void {
         const surface: *impl.Surface = @ptrCast(@alignCast(surface_raw));
         surface.manager.release();
     }
 
-    pub inline fn swapChainConfigure(swap_chain: *gpu.SwapChain, format: gpu.Texture.Format, allowed_usage: gpu.Texture.UsageFlags, width: u32, height: u32) void {
+    pub inline fn swapChainConfigure(swap_chain: *dgpu.SwapChain, format: dgpu.Texture.Format, allowed_usage: dgpu.Texture.UsageFlags, width: u32, height: u32) void {
         _ = swap_chain;
         _ = format;
         _ = allowed_usage;
@@ -1265,111 +1264,111 @@ pub const Impl = struct {
         unreachable;
     }
 
-    pub inline fn swapChainGetCurrentTexture(swap_chain: *gpu.SwapChain) ?*gpu.Texture {
+    pub inline fn swapChainGetCurrentTexture(swap_chain: *dgpu.SwapChain) ?*dgpu.Texture {
         _ = swap_chain;
         unreachable;
     }
 
-    pub inline fn swapChainGetCurrentTextureView(swap_chain_raw: *gpu.SwapChain) ?*gpu.TextureView {
+    pub inline fn swapChainGetCurrentTextureView(swap_chain_raw: *dgpu.SwapChain) ?*dgpu.TextureView {
         const swap_chain: *impl.SwapChain = @ptrCast(@alignCast(swap_chain_raw));
         const texture_view = swap_chain.getCurrentTextureView() catch unreachable;
         return @ptrCast(texture_view);
     }
 
-    pub inline fn swapChainPresent(swap_chain_raw: *gpu.SwapChain) void {
+    pub inline fn swapChainPresent(swap_chain_raw: *dgpu.SwapChain) void {
         const swap_chain: *impl.SwapChain = @ptrCast(@alignCast(swap_chain_raw));
         swap_chain.present() catch unreachable;
     }
 
-    pub inline fn swapChainReference(swap_chain_raw: *gpu.SwapChain) void {
+    pub inline fn swapChainReference(swap_chain_raw: *dgpu.SwapChain) void {
         const swap_chain: *impl.SwapChain = @ptrCast(@alignCast(swap_chain_raw));
         swap_chain.manager.reference();
     }
 
-    pub inline fn swapChainRelease(swap_chain_raw: *gpu.SwapChain) void {
+    pub inline fn swapChainRelease(swap_chain_raw: *dgpu.SwapChain) void {
         const swap_chain: *impl.SwapChain = @ptrCast(@alignCast(swap_chain_raw));
         swap_chain.manager.release();
     }
 
-    pub inline fn textureCreateView(texture_raw: *gpu.Texture, descriptor: ?*const gpu.TextureView.Descriptor) *gpu.TextureView {
+    pub inline fn textureCreateView(texture_raw: *dgpu.Texture, descriptor: ?*const dgpu.TextureView.Descriptor) *dgpu.TextureView {
         const texture: *impl.Texture = @ptrCast(@alignCast(texture_raw));
         const texture_view = texture.createView(descriptor) catch unreachable;
         return @ptrCast(texture_view);
     }
 
-    pub inline fn textureDestroy(texture: *gpu.Texture) void {
+    pub inline fn textureDestroy(texture: *dgpu.Texture) void {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetDepthOrArrayLayers(texture: *gpu.Texture) u32 {
+    pub inline fn textureGetDepthOrArrayLayers(texture: *dgpu.Texture) u32 {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetDimension(texture: *gpu.Texture) gpu.Texture.Dimension {
+    pub inline fn textureGetDimension(texture: *dgpu.Texture) dgpu.Texture.Dimension {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetFormat(texture: *gpu.Texture) gpu.Texture.Format {
+    pub inline fn textureGetFormat(texture: *dgpu.Texture) dgpu.Texture.Format {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetHeight(texture: *gpu.Texture) u32 {
+    pub inline fn textureGetHeight(texture: *dgpu.Texture) u32 {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetMipLevelCount(texture: *gpu.Texture) u32 {
+    pub inline fn textureGetMipLevelCount(texture: *dgpu.Texture) u32 {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetSampleCount(texture: *gpu.Texture) u32 {
+    pub inline fn textureGetSampleCount(texture: *dgpu.Texture) u32 {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetUsage(texture: *gpu.Texture) gpu.Texture.UsageFlags {
+    pub inline fn textureGetUsage(texture: *dgpu.Texture) dgpu.Texture.UsageFlags {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureGetWidth(texture: *gpu.Texture) u32 {
+    pub inline fn textureGetWidth(texture: *dgpu.Texture) u32 {
         _ = texture;
         unreachable;
     }
 
-    pub inline fn textureSetLabel(texture: *gpu.Texture, label: [*:0]const u8) void {
+    pub inline fn textureSetLabel(texture: *dgpu.Texture, label: [*:0]const u8) void {
         _ = texture;
         _ = label;
         unreachable;
     }
 
-    pub inline fn textureReference(texture_raw: *gpu.Texture) void {
+    pub inline fn textureReference(texture_raw: *dgpu.Texture) void {
         const texture: *impl.Texture = @ptrCast(@alignCast(texture_raw));
         texture.manager.reference();
     }
 
-    pub inline fn textureRelease(texture_raw: *gpu.Texture) void {
+    pub inline fn textureRelease(texture_raw: *dgpu.Texture) void {
         const texture: *impl.Texture = @ptrCast(@alignCast(texture_raw));
         texture.manager.release();
     }
 
-    pub inline fn textureViewSetLabel(texture_view: *gpu.TextureView, label: [*:0]const u8) void {
+    pub inline fn textureViewSetLabel(texture_view: *dgpu.TextureView, label: [*:0]const u8) void {
         _ = texture_view;
         _ = label;
         unreachable;
     }
 
-    pub inline fn textureViewReference(texture_view_raw: *gpu.TextureView) void {
+    pub inline fn textureViewReference(texture_view_raw: *dgpu.TextureView) void {
         const texture_view: *impl.TextureView = @ptrCast(@alignCast(texture_view_raw));
         texture_view.manager.reference();
     }
 
-    pub inline fn textureViewRelease(texture_view_raw: *gpu.TextureView) void {
+    pub inline fn textureViewRelease(texture_view_raw: *dgpu.TextureView) void {
         const texture_view: *impl.TextureView = @ptrCast(@alignCast(texture_view_raw));
         texture_view.manager.release();
     }
@@ -1380,5 +1379,5 @@ test "refAllDeclsRecursive" {
 }
 
 test "export" {
-    _ = gpu.Export(Impl);
+    _ = dgpu.Export(Impl);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const gpu = @import("gpu");
+pub const dgpu = @import("dgpu/main.zig");
 const shader = @import("shader.zig");
 const utils = @import("utils.zig");
 
@@ -20,7 +21,7 @@ const impl = switch (backend_type) {
 var inited = false;
 var allocator: std.mem.Allocator = undefined;
 
-pub const Interface = struct {
+pub const Impl = struct {
     pub fn init(alloc: std.mem.Allocator, options: impl.InitOptions) !void {
         inited = true;
         allocator = alloc;
@@ -1379,5 +1380,5 @@ test "refAllDeclsRecursive" {
 }
 
 test "export" {
-    _ = gpu.Export(Interface);
+    _ = gpu.Export(Impl);
 }

--- a/src/metal/conv.zig
+++ b/src/metal/conv.zig
@@ -1,7 +1,7 @@
-const gpu = @import("gpu");
 const mtl = @import("objc").metal.mtl;
+const dgpu = @import("../dgpu/main.zig");
 
-pub fn metalBlendFactor(factor: gpu.BlendFactor) mtl.BlendFactor {
+pub fn metalBlendFactor(factor: dgpu.BlendFactor) mtl.BlendFactor {
     return switch (factor) {
         .zero => mtl.BlendFactorZero,
         .one => mtl.BlendFactorOne,
@@ -23,7 +23,7 @@ pub fn metalBlendFactor(factor: gpu.BlendFactor) mtl.BlendFactor {
     };
 }
 
-pub fn metalBlendOperation(op: gpu.BlendOperation) mtl.BlendOperation {
+pub fn metalBlendOperation(op: dgpu.BlendOperation) mtl.BlendOperation {
     return switch (op) {
         .add => mtl.BlendOperationAdd,
         .subtract => mtl.BlendOperationSubtract,
@@ -33,7 +33,7 @@ pub fn metalBlendOperation(op: gpu.BlendOperation) mtl.BlendOperation {
     };
 }
 
-pub fn metalColorWriteMask(mask: gpu.ColorWriteMaskFlags) mtl.ColorWriteMask {
+pub fn metalColorWriteMask(mask: dgpu.ColorWriteMaskFlags) mtl.ColorWriteMask {
     var writeMask = mtl.ColorWriteMaskNone;
     if (mask.red)
         writeMask |= mtl.ColorWriteMaskRed;
@@ -46,7 +46,7 @@ pub fn metalColorWriteMask(mask: gpu.ColorWriteMaskFlags) mtl.ColorWriteMask {
     return writeMask;
 }
 
-pub fn metalCommonCounter(name: gpu.PipelineStatisticName) mtl.CommonCounter {
+pub fn metalCommonCounter(name: dgpu.PipelineStatisticName) mtl.CommonCounter {
     return switch (name) {
         .vertex_shader_invocations => mtl.CommonCounterVertexInvocations,
         .cliiper_invocations => mtl.CommonCounterClipperInvocations,
@@ -56,7 +56,7 @@ pub fn metalCommonCounter(name: gpu.PipelineStatisticName) mtl.CommonCounter {
     };
 }
 
-pub fn metalCompareFunction(func: gpu.CompareFunction) mtl.CompareFunction {
+pub fn metalCompareFunction(func: dgpu.CompareFunction) mtl.CompareFunction {
     return switch (func) {
         .undefined => unreachable,
         .never => mtl.CompareFunctionNever,
@@ -70,7 +70,7 @@ pub fn metalCompareFunction(func: gpu.CompareFunction) mtl.CompareFunction {
     };
 }
 
-pub fn metalCullMode(mode: gpu.CullMode) mtl.CullMode {
+pub fn metalCullMode(mode: dgpu.CullMode) mtl.CullMode {
     return switch (mode) {
         .none => mtl.CullModeNone,
         .front => mtl.CullModeFront,
@@ -78,14 +78,14 @@ pub fn metalCullMode(mode: gpu.CullMode) mtl.CullMode {
     };
 }
 
-pub fn metalIndexType(face: gpu.FrontFace) mtl.IndexType {
+pub fn metalIndexType(face: dgpu.FrontFace) mtl.IndexType {
     return switch (face) {
         .uint16 => mtl.IndexTypeUInt16,
         .uint32 => mtl.IndexTypeUInt32,
     };
 }
 
-pub fn metalLoadAction(op: gpu.LoadOp) mtl.LoadAction {
+pub fn metalLoadAction(op: dgpu.LoadOp) mtl.LoadAction {
     return switch (op) {
         .undefined => unreachable,
         .load => mtl.LoadActionLoad,
@@ -93,7 +93,7 @@ pub fn metalLoadAction(op: gpu.LoadOp) mtl.LoadAction {
     };
 }
 
-pub fn metalPixelFormat(format: gpu.Texture.Format) mtl.PixelFormat {
+pub fn metalPixelFormat(format: dgpu.Texture.Format) mtl.PixelFormat {
     return switch (format) {
         .undefined => mtl.PixelFormatInvalid,
         .r8_unorm => mtl.PixelFormatR8Unorm,
@@ -194,7 +194,7 @@ pub fn metalPixelFormat(format: gpu.Texture.Format) mtl.PixelFormat {
     };
 }
 
-pub fn metalPixelFormatForView(viewFormat: gpu.Texture.Format, textureFormat: mtl.PixelFormat, aspect: gpu.Texture.Aspect) mtl.PixelFormat {
+pub fn metalPixelFormatForView(viewFormat: dgpu.Texture.Format, textureFormat: mtl.PixelFormat, aspect: dgpu.Texture.Aspect) mtl.PixelFormat {
     // TODO - depth/stencil only views
     _ = aspect;
     _ = textureFormat;
@@ -202,7 +202,7 @@ pub fn metalPixelFormatForView(viewFormat: gpu.Texture.Format, textureFormat: mt
     return metalPixelFormat(viewFormat);
 }
 
-pub fn metalPrimitiveTopologyClass(topology: gpu.PrimitiveTopology) mtl.PrimitiveTopologyClass {
+pub fn metalPrimitiveTopologyClass(topology: dgpu.PrimitiveTopology) mtl.PrimitiveTopologyClass {
     return switch (topology) {
         .point_list => mtl.PrimitiveTopologyClassPoint,
         .line_list => mtl.PrimitiveTopologyClassLine,
@@ -212,7 +212,7 @@ pub fn metalPrimitiveTopologyClass(topology: gpu.PrimitiveTopology) mtl.Primitiv
     };
 }
 
-pub fn metalPrimitiveType(topology: gpu.PrimitiveTopology) mtl.PrimitiveType {
+pub fn metalPrimitiveType(topology: dgpu.PrimitiveTopology) mtl.PrimitiveType {
     return switch (topology) {
         .point_list => mtl.PrimitiveTypePoint,
         .line_list => mtl.PrimitiveTypeLine,
@@ -222,14 +222,14 @@ pub fn metalPrimitiveType(topology: gpu.PrimitiveTopology) mtl.PrimitiveType {
     };
 }
 
-pub fn metalResourceOptionsForBuffer(usage: gpu.Buffer.UsageFlags) mtl.ResourceOptions {
+pub fn metalResourceOptionsForBuffer(usage: dgpu.Buffer.UsageFlags) mtl.ResourceOptions {
     const cpu_cache_mode = if (usage.map_write and !usage.map_read) mtl.ResourceCPUCacheModeWriteCombined else mtl.ResourceCPUCacheModeDefaultCache;
     const storage_mode = mtl.ResourceStorageModeShared; // optimizing for UMA only
     const hazard_tracking_mode = mtl.ResourceHazardTrackingModeDefault;
     return cpu_cache_mode | storage_mode | hazard_tracking_mode;
 }
 
-pub fn metalSamplerAddressMode(mode: gpu.AddressMode) mtl.SamplerAddressMode {
+pub fn metalSamplerAddressMode(mode: dgpu.AddressMode) mtl.SamplerAddressMode {
     return switch (mode) {
         .repeat => mtl.SamplerAddressModeRepeat,
         .mirror_repeat => mtl.SamplerAddressModeMirrorRepeat,
@@ -237,21 +237,21 @@ pub fn metalSamplerAddressMode(mode: gpu.AddressMode) mtl.SamplerAddressMode {
     };
 }
 
-pub fn metalSamplerMinMagFilter(mode: gpu.FilterMode) mtl.SamplerMinMagFilter {
+pub fn metalSamplerMinMagFilter(mode: dgpu.FilterMode) mtl.SamplerMinMagFilter {
     return switch (mode) {
         .nearest => mtl.SamplerMinMagFilterNearest,
         .linear => mtl.SamplerMinMagFilterLinear,
     };
 }
 
-pub fn metalSamplerMipFilter(mode: gpu.MipmapFilterMode) mtl.SamplerMipFilter {
+pub fn metalSamplerMipFilter(mode: dgpu.MipmapFilterMode) mtl.SamplerMipFilter {
     return switch (mode) {
         .nearest => mtl.SamplerMipFilterNearest,
         .linear => mtl.SamplerMipFilterLinear,
     };
 }
 
-pub fn metalStencilOperation(op: gpu.StencilOperation) mtl.StencilOperation {
+pub fn metalStencilOperation(op: dgpu.StencilOperation) mtl.StencilOperation {
     return switch (op) {
         .keep => mtl.StencilOperationKeep,
         .zero => mtl.StencilOperationZero,
@@ -264,7 +264,7 @@ pub fn metalStencilOperation(op: gpu.StencilOperation) mtl.StencilOperation {
     };
 }
 
-pub fn metalStorageModeForTexture(usage: gpu.Texture.UsageFlags) mtl.StorageMode {
+pub fn metalStorageModeForTexture(usage: dgpu.Texture.UsageFlags) mtl.StorageMode {
     if (usage.transient_attachment) {
         return mtl.StorageModeMemoryless;
     } else {
@@ -272,7 +272,7 @@ pub fn metalStorageModeForTexture(usage: gpu.Texture.UsageFlags) mtl.StorageMode
     }
 }
 
-pub fn metalStoreAction(op: gpu.StoreOp, has_resolve_target: bool) mtl.StoreAction {
+pub fn metalStoreAction(op: dgpu.StoreOp, has_resolve_target: bool) mtl.StoreAction {
     return switch (op) {
         .undefined => unreachable,
         .store => if (has_resolve_target) mtl.StoreActionStoreAndMultisampleResolve else mtl.StoreActionStore,
@@ -280,7 +280,7 @@ pub fn metalStoreAction(op: gpu.StoreOp, has_resolve_target: bool) mtl.StoreActi
     };
 }
 
-pub fn metalTextureType(dimension: gpu.Texture.Dimension, size: gpu.Extent3D, sample_count: u32) mtl.TextureType {
+pub fn metalTextureType(dimension: dgpu.Texture.Dimension, size: dgpu.Extent3D, sample_count: u32) mtl.TextureType {
     return switch (dimension) {
         .dimension_1d => if (size.depth_or_array_layers > 1) mtl.TextureType1DArray else mtl.TextureType1D,
         .dimension_2d => if (sample_count > 1)
@@ -296,7 +296,7 @@ pub fn metalTextureType(dimension: gpu.Texture.Dimension, size: gpu.Extent3D, sa
     };
 }
 
-pub fn metalTextureTypeForView(dimension: gpu.TextureView.Dimension) mtl.TextureType {
+pub fn metalTextureTypeForView(dimension: dgpu.TextureView.Dimension) mtl.TextureType {
     return switch (dimension) {
         .dimension_undefined => unreachable,
         .dimension_1d => mtl.TextureType1D,
@@ -308,7 +308,7 @@ pub fn metalTextureTypeForView(dimension: gpu.TextureView.Dimension) mtl.Texture
     };
 }
 
-pub fn metalTextureUsage(usage: gpu.Texture.UsageFlags, view_format_count: usize) mtl.TextureUsage {
+pub fn metalTextureUsage(usage: dgpu.Texture.UsageFlags, view_format_count: usize) mtl.TextureUsage {
     var mtl_usage = mtl.TextureUsageUnknown;
     if (usage.texture_binding)
         mtl_usage |= mtl.TextureUsageShaderRead;
@@ -321,7 +321,7 @@ pub fn metalTextureUsage(usage: gpu.Texture.UsageFlags, view_format_count: usize
     return mtl_usage;
 }
 
-pub fn metalVertexFormat(format: gpu.VertexFormat) mtl.VertexFormat {
+pub fn metalVertexFormat(format: dgpu.VertexFormat) mtl.VertexFormat {
     return switch (format) {
         .undefined => mtl.VertexFormatInvalid,
         .uint8x2 => mtl.VertexFormatUChar2,
@@ -357,7 +357,7 @@ pub fn metalVertexFormat(format: gpu.VertexFormat) mtl.VertexFormat {
     };
 }
 
-pub fn metalVertexStepFunction(mode: gpu.VertexStepMode) mtl.VertexStepFunction {
+pub fn metalVertexStepFunction(mode: dgpu.VertexStepMode) mtl.VertexStepFunction {
     return switch (mode) {
         .vertex => mtl.VertexStepFunctionPerVertex,
         .instance => mtl.VertexStepFunctionPerInstance,
@@ -365,7 +365,7 @@ pub fn metalVertexStepFunction(mode: gpu.VertexStepMode) mtl.VertexStepFunction 
     };
 }
 
-pub fn metalWinding(face: gpu.FrontFace) mtl.Winding {
+pub fn metalWinding(face: dgpu.FrontFace) mtl.Winding {
     return switch (face) {
         .ccw => mtl.WindingCounterClockwise,
         .cw => mtl.WindingClockwise,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const gpu = @import("gpu");
+const dgpu = @import("dgpu/main.zig");
 
 pub fn Manager(comptime T: type) type {
     return struct {
@@ -19,8 +19,8 @@ pub fn Manager(comptime T: type) type {
     };
 }
 
-pub fn findChained(comptime T: type, next_in_chain: ?*const gpu.ChainedStruct) ?*const T {
-    const search = @as(*align(1) const gpu.ChainedStruct, @ptrCast(std.meta.fieldInfo(T, .chain).default_value.?));
+pub fn findChained(comptime T: type, next_in_chain: ?*const dgpu.ChainedStruct) ?*const T {
+    const search = @as(*align(1) const dgpu.ChainedStruct, @ptrCast(std.meta.fieldInfo(T, .chain).default_value.?));
     var chain = next_in_chain;
     while (chain) |c| {
         if (c.s_type == search.s_type) {

--- a/src/vulkan/conv.zig
+++ b/src/vulkan/conv.zig
@@ -1,7 +1,7 @@
-const gpu = @import("gpu");
 const vk = @import("vulkan");
+const dgpu = @import("../dgpu/main.zig");
 
-pub fn vulkanBlendOp(op: gpu.BlendOperation) vk.BlendOp {
+pub fn vulkanBlendOp(op: dgpu.BlendOperation) vk.BlendOp {
     return switch (op) {
         .add => .add,
         .subtract => .subtract,
@@ -11,7 +11,7 @@ pub fn vulkanBlendOp(op: gpu.BlendOperation) vk.BlendOp {
     };
 }
 
-pub fn vulkanBlendFactor(op: gpu.BlendFactor) vk.BlendFactor {
+pub fn vulkanBlendFactor(op: dgpu.BlendFactor) vk.BlendFactor {
     return switch (op) {
         .zero => .zero,
         .one => .one,
@@ -33,7 +33,7 @@ pub fn vulkanBlendFactor(op: gpu.BlendFactor) vk.BlendFactor {
     };
 }
 
-pub fn vulkanCompareOp(op: gpu.CompareFunction) vk.CompareOp {
+pub fn vulkanCompareOp(op: dgpu.CompareFunction) vk.CompareOp {
     return switch (op) {
         .never => .never,
         .less => .less,
@@ -47,22 +47,22 @@ pub fn vulkanCompareOp(op: gpu.CompareFunction) vk.CompareOp {
     };
 }
 
-pub fn vulkanDepthBias(ds: ?*const gpu.DepthStencilState) f32 {
+pub fn vulkanDepthBias(ds: ?*const dgpu.DepthStencilState) f32 {
     if (ds == null) return 0;
     return @floatFromInt(ds.?.depth_bias);
 }
 
-pub fn vulkanDepthBiasClamp(ds: ?*const gpu.DepthStencilState) f32 {
+pub fn vulkanDepthBiasClamp(ds: ?*const dgpu.DepthStencilState) f32 {
     if (ds == null) return 0;
     return ds.?.depth_bias_clamp;
 }
 
-pub fn vulkanDepthBiasSlopeScale(ds: ?*const gpu.DepthStencilState) f32 {
+pub fn vulkanDepthBiasSlopeScale(ds: ?*const dgpu.DepthStencilState) f32 {
     if (ds == null) return 0;
     return ds.?.depth_bias_slope_scale;
 }
 
-pub fn vulkanFormat(format: gpu.Texture.Format) vk.Format {
+pub fn vulkanFormat(format: dgpu.Texture.Format) vk.Format {
     return switch (format) {
         .r8_unorm => .r8_unorm,
         .r8_snorm => .r8_snorm,
@@ -176,7 +176,7 @@ pub fn vulkanSampleCount(samples: u32) vk.SampleCountFlags {
     };
 }
 
-pub fn vulkanStencilOp(op: gpu.StencilOperation) vk.StencilOp {
+pub fn vulkanStencilOp(op: dgpu.StencilOperation) vk.StencilOp {
     return switch (op) {
         .keep => .keep,
         .zero => .zero,
@@ -189,7 +189,7 @@ pub fn vulkanStencilOp(op: gpu.StencilOperation) vk.StencilOp {
     };
 }
 
-pub fn vulkanLoadOp(op: gpu.LoadOp) vk.AttachmentLoadOp {
+pub fn vulkanLoadOp(op: dgpu.LoadOp) vk.AttachmentLoadOp {
     return switch (op) {
         .load => .load,
         .clear => .clear,
@@ -197,7 +197,7 @@ pub fn vulkanLoadOp(op: gpu.LoadOp) vk.AttachmentLoadOp {
     };
 }
 
-pub fn vulkanStoreOp(op: gpu.StoreOp) vk.AttachmentStoreOp {
+pub fn vulkanStoreOp(op: dgpu.StoreOp) vk.AttachmentStoreOp {
     return switch (op) {
         .store => .store,
         .discard => .dont_care,
@@ -205,7 +205,7 @@ pub fn vulkanStoreOp(op: gpu.StoreOp) vk.AttachmentStoreOp {
     };
 }
 
-pub fn vulkanVertexFormat(format: gpu.VertexFormat) vk.Format {
+pub fn vulkanVertexFormat(format: dgpu.VertexFormat) vk.Format {
     return switch (format) {
         .uint8x2 => .r8g8_uint,
         .uint8x4 => .r8g8b8a8_uint,
@@ -241,7 +241,7 @@ pub fn vulkanVertexFormat(format: gpu.VertexFormat) vk.Format {
     };
 }
 
-pub fn vulkanDescriptorType(entry: gpu.BindGroupLayout.Entry) vk.DescriptorType {
+pub fn vulkanDescriptorType(entry: dgpu.BindGroupLayout.Entry) vk.DescriptorType {
     switch (entry.buffer.type) {
         .undefined => {},
 
@@ -279,7 +279,7 @@ pub fn vulkanDescriptorType(entry: gpu.BindGroupLayout.Entry) vk.DescriptorType 
     unreachable;
 }
 
-pub fn vulkanShaderStageFlags(flags: gpu.ShaderStageFlags) vk.ShaderStageFlags {
+pub fn vulkanShaderStageFlags(flags: dgpu.ShaderStageFlags) vk.ShaderStageFlags {
     return .{
         .vertex_bit = flags.vertex,
         .fragment_bit = flags.fragment,
@@ -287,7 +287,7 @@ pub fn vulkanShaderStageFlags(flags: gpu.ShaderStageFlags) vk.ShaderStageFlags {
     };
 }
 
-pub fn vulkanBufferUsageFlags(flags: gpu.Buffer.UsageFlags) vk.BufferUsageFlags {
+pub fn vulkanBufferUsageFlags(flags: dgpu.Buffer.UsageFlags) vk.BufferUsageFlags {
     return .{
         .transfer_src_bit = flags.copy_src,
         .transfer_dst_bit = flags.copy_dst or flags.query_resolve,


### PR DESCRIPTION
This effectively copies the WebGPU/mach-gpu `gpu.Interface` and instead lets Dusk define it. For now, it's almost a 1:1 copy and almost entirely commented out.

This is the first step in having Dusk graduate from being a WebGPU implementation.. to being a WebGPU competitor, which can use WebGPU behind the scenes as one of its backends.

The reason to do this the same way as `gpu.Interface` is that we should keep in mind C ABI compatibility, and the ability to intercept GPU API calls for the purposes of debugging tooling in the future.

We should carefully review which portions of the WebGPU API we want to keep, and which ones we want to change for a render graph API.

![image](https://github.com/hexops/mach-dusk/assets/3173176/7d382603-e4f8-4448-ae48-2b3a9292ae96)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.