### PR TITLE
check that attribute group integer is constant

### DIFF
--- a/src/shader/AstGen.zig
+++ b/src/shader/AstGen.zig
@@ -709,18 +709,18 @@ fn attrGroup(astgen: *AstGen, scope: *Scope, node: NodeIndex) !InstIndex {
     const node_lhs_loc = astgen.tree.nodeLoc(node_lhs);
     const group = try astgen.genExpr(scope, node_lhs);
 
-    const group_res = try astgen.resolve(group);
-    if (astgen.getInst(group_res) != .int) {
+    const inst = astgen.getInst(try astgen.resolve(group));
+    if (inst != .int or inst.int.value == null) {
         try astgen.errors.add(
             node_lhs_loc,
-            "group value must be integer",
+            "group value must be a constant integer",
             .{},
             null,
         );
         return error.AnalysisFail;
     }
 
-    if (astgen.getValue(Inst.Int.Value, astgen.getInst(group_res).int.value.?).literal < 0) {
+    if (astgen.getValue(Inst.Int.Value, inst.int.value.?).literal < 0) {
         try astgen.errors.add(
             node_lhs_loc,
             "group value must be a positive",


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Fix this:
```wgsl
const mesh: u32 = 3;
@group(mesh) @binding(0) var<uniform> strides: Strides;
```

Crashing IR with:
```
thread 278966 panic: attempt to use null value
/home/thesm/src/wgsl-linker/src/shader/AstGen.zig:723:76: 0x298f85 in attrGroup (wgsl-linker)
    if (astgen.getValue(Inst.Int.Value, astgen.getInst(group_res).int.value.?).literal < 0) {
```