### PR TITLE
metal: deinit queue

### DIFF
--- a/src/metal.zig
+++ b/src/metal.zig
@@ -197,7 +197,10 @@ pub const Device = struct {
         device.map_callbacks.deinit(allocator);
         device.reference_trackers.deinit(allocator);
         device.streaming_manager.deinit();
-        if (device.queue) |queue| queue.manager.release();
+        if (device.queue) |queue| {
+            queue.manager.release();
+            queue.deinit();
+        }
         allocator.destroy(device);
     }
 


### PR DESCRIPTION
Please close if this is incorrect, but I was checking my projects and both running on metal had errors on close pointing to `device.queue` , it seems like this just simply was missed during `core.deinit()`.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.